### PR TITLE
remove product/priv-app/SSRestartDetector

### DIFF
--- a/config/common/file-removal.yml
+++ b/config/common/file-removal.yml
@@ -228,6 +228,7 @@ filters:
       - product/priv-app/Showcase
       - product/priv-app/SprintDM
       - product/priv-app/SprintHM
+      - product/priv-app/SSRestartDetector
       - product/priv-app/TetheringEntitlement
       - product/priv-app/TipsPrebuilt
       - product/priv-app/TurboPrebuilt


### PR DESCRIPTION
Keep its old location (product/app/SSRestartDetector) in removal list for now.