### PR TITLE
remove android:string/config_systemBluetoothStack overlay

### DIFF
--- a/config/common/overlay-removal.yml
+++ b/config/common/overlay-removal.yml
@@ -153,6 +153,7 @@ filters:
       - android:string/config_systemAppProtectionService
       - android:string/config_systemAudioIntelligence
       - android:string/config_systemAutomotiveProjection
+      - android:string/config_systemBluetoothStack
       - android:string/config_systemCompanionDeviceProvider
       - android:string/config_systemContacts
       - android:string/config_systemGallery


### PR DESCRIPTION
It's set to com.google.android.bluetooth since 13 QPR2. AOSP's default value is correctly set to com.android.bluetooth.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/2020