### PR TITLE
ship vendor camera extensions properties

### DIFF
--- a/config/common/removal.yml
+++ b/config/common/removal.yml
@@ -39,8 +39,6 @@ filters:
       - ro.com.android.prov_mobiledata
       # privapps
       - ro.control_privapp_permissions
-      # unused camera2 extensions
-      - ro.vendor.camera.extensions
       # unused carrier setup page
       - ro.carriersetup.vzw_consent_page
       # unused gms props


### PR DESCRIPTION
This makes Pixel Camera Services the provider of camera extensions. Requires frameworks/base changes for validation of package that provides vendor camera extensions.