### PR TITLE
remove connectivity_thermal_power_manager sepolicy

### DIFF
--- a/config/common/removal.yml
+++ b/config/common/removal.yml
@@ -58,3 +58,4 @@ filters:
       - hardware/google/pixel-sepolicy/ramdump
       - hardware/google/pixel-sepolicy/sota_app/system_ext
       - hardware/google/pixel-sepolicy/turbo_adapter
+      - hardware/google/pixel-sepolicy/connectivity_thermal_power_manager


### PR DESCRIPTION
we do not ship com.google.android.connectivitythermalpowermanager