### PR TITLE
use debugfs to dump filesystem images by default

### DIFF
--- a/src/commands/check-presigned.ts
+++ b/src/commands/check-presigned.ts
@@ -35,7 +35,7 @@ export default class CheckPresigned extends Command {
 
   async run() {
     let {
-      flags: { aapt2: aapt2Path, sepolicy: sepolicyDirs, outList: outPath, device, stockSrc, buildId, useTemp },
+      flags: { aapt2: aapt2Path, sepolicy: sepolicyDirs, outList: outPath, device, stockSrc, buildId, useTemp, useMount },
       args: { listPath },
     } = this.parse(CheckPresigned)
 
@@ -47,7 +47,7 @@ export default class CheckPresigned extends Command {
     // Find and parse sepolicy seapp_contexts
     let presignedPkgs = await parsePresignedRecursive(sepolicyDirs)
 
-    await withWrappedSrc(stockSrc, device, buildId, useTemp, async stockSrc => {
+    await withWrappedSrc(stockSrc, device, buildId, useTemp, useMount, async stockSrc => {
       if (entries != null) {
         // Get APKs from blob entries
         let presignedEntries = await updatePresignedBlobs(aapt2Path, stockSrc, presignedPkgs, entries)

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -26,10 +26,10 @@ export default class Extract extends Command {
   async run() {
     let {
       args: { listPath },
-      flags: { vendor, device, skipCopy, stockSrc, buildId, useTemp },
+      flags: { vendor, device, skipCopy, stockSrc, buildId, useTemp, useMount },
     } = this.parse(Extract)
 
-    await withWrappedSrc(stockSrc, device, buildId, useTemp, async stockSrc => {
+    await withWrappedSrc(stockSrc, device, buildId, useTemp, useMount, async stockSrc => {
       // Parse list
       this.log(chalk.bold(chalk.greenBright('Parsing list')))
       let list = await readFile(listPath)

--- a/src/commands/fix-certs.ts
+++ b/src/commands/fix-certs.ts
@@ -29,10 +29,10 @@ export default class FixCerts extends Command {
 
   async run() {
     let {
-      flags: { sepolicy: sepolicyDirs, device, buildId, stockSrc, useTemp },
+      flags: { sepolicy: sepolicyDirs, device, buildId, stockSrc, useTemp, useMount },
     } = this.parse(FixCerts)
 
-    await withWrappedSrc(stockSrc, device, buildId, useTemp, async stockSrc => {
+    await withWrappedSrc(stockSrc, device, buildId, useTemp, useMount, async stockSrc => {
       let srcSigners: Array<MacSigner> = []
       let srcKeys: Array<KeyInfo> = []
       for (let dir of sepolicyDirs) {

--- a/src/commands/generate-all.ts
+++ b/src/commands/generate-all.ts
@@ -34,12 +34,13 @@ const doDevice = (
   factoryPath: string | undefined,
   skipCopy: boolean,
   useTemp: boolean,
+  useMount: boolean,
 ) =>
   withTempDir(async tmp => {
     // Prepare stock system source
     let wrapBuildId = buildId == undefined ? null : buildId
     let wrapped = await withSpinner('Extracting stock system source', spinner =>
-      wrapSystemSrc(stockSrc, config.device.name, wrapBuildId, useTemp, tmp, spinner),
+      wrapSystemSrc(stockSrc, config.device.name, wrapBuildId, useTemp, useMount, tmp, spinner),
     )
     stockSrc = wrapped.src!
     if (wrapped.factoryPath != null && factoryPath == undefined) {
@@ -81,7 +82,7 @@ const doDevice = (
     // 4. Flatten APEX modules
     if (config.generate.flat_apex) {
       entries = await withSpinner('Flattening APEX modules', spinner =>
-        flattenApexs(spinner, entries, dirs, tmp, stockSrc),
+        flattenApexs(spinner, entries, dirs, useMount, tmp, stockSrc),
       )
     }
 
@@ -189,7 +190,7 @@ export default class GenerateFull extends Command {
 
   async run() {
     let {
-      flags: { aapt2: aapt2Path, buildId, stockSrc, customSrc, factoryPath, skipCopy, useTemp, parallel },
+      flags: { aapt2: aapt2Path, buildId, stockSrc, customSrc, factoryPath, skipCopy, useTemp, useMount, parallel },
       args: { config: configPath },
     } = this.parse(GenerateFull)
 
@@ -199,7 +200,7 @@ export default class GenerateFull extends Command {
       devices,
       parallel,
       async config => {
-        await doDevice(config, stockSrc, customSrc, aapt2Path, buildId, factoryPath, skipCopy, useTemp)
+        await doDevice(config, stockSrc, customSrc, aapt2Path, buildId, factoryPath, skipCopy, useTemp, useMount)
       },
       config => config.device.name,
     )

--- a/src/commands/generate-prep.ts
+++ b/src/commands/generate-prep.ts
@@ -16,12 +16,13 @@ const doDevice = (
   buildId: string | undefined,
   skipCopy: boolean,
   useTemp: boolean,
+  useMount: boolean,
 ) =>
   withTempDir(async tmp => {
     // Prepare stock system source
     let wrapBuildId = buildId == undefined ? null : buildId
     let wrapped = await withSpinner('Extracting stock system source', spinner =>
-      wrapSystemSrc(stockSrc, config.device.name, wrapBuildId, useTemp, tmp, spinner),
+      wrapSystemSrc(stockSrc, config.device.name, wrapBuildId, useTemp, useMount, tmp, spinner),
     )
     stockSrc = wrapped.src!
 
@@ -82,7 +83,7 @@ export default class GeneratePrep extends Command {
 
   async run() {
     let {
-      flags: { buildId, stockSrc, skipCopy, useTemp, parallel },
+      flags: { buildId, stockSrc, skipCopy, useTemp, useMount, parallel },
       args: { config: configPath },
     } = this.parse(GeneratePrep)
 
@@ -92,7 +93,7 @@ export default class GeneratePrep extends Command {
       devices,
       parallel,
       async config => {
-        await doDevice(config, stockSrc, buildId, skipCopy, useTemp)
+        await doDevice(config, stockSrc, buildId, skipCopy, useTemp, useMount)
       },
       config => config.device.name,
     )

--- a/src/commands/list-files.ts
+++ b/src/commands/list-files.ts
@@ -21,11 +21,11 @@ export default class ListFiles extends Command {
 
   async run() {
     let {
-      flags: { device, stockSrc, buildId, useTemp },
+      flags: { device, stockSrc, buildId, useTemp, useMount },
       args: { out },
     } = this.parse(ListFiles)
 
-    await withWrappedSrc(stockSrc, device, buildId, useTemp, async stockSrc => {
+    await withWrappedSrc(stockSrc, device, buildId, useTemp, useMount, async stockSrc => {
       await fs.mkdir(out, {recursive: true})
 
       for (let partition of ALL_SYS_PARTITIONS) {

--- a/src/frontend/generate.ts
+++ b/src/frontend/generate.ts
@@ -134,10 +134,11 @@ export async function flattenApexs(
   spinner: ora.Ora,
   entries: BlobEntry[],
   dirs: VendorDirectories,
+  useMount: boolean,
   tmp: TempState,
   stockSrc: string,
 ) {
-  let apex = await flattenAllApexs(entries, stockSrc, tmp, progress => {
+  let apex = await flattenAllApexs(entries, stockSrc, useMount, tmp, progress => {
     spinner.text = progress
   })
 

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -76,3 +76,7 @@ export async function readFile(path: string) {
 export async function mount(imgPath: string, mountpoint: string) {
   await run(`mount -o ro ${imgPath} ${mountpoint}`)
 }
+
+export async function dump(imgPath: string, destination: string) {
+  await run(`debugfs -R 'rdump / ${destination}' ${imgPath}`)
+}


### PR DESCRIPTION
Old method of mounting images can be used by passing `--useMount` command line flag.