### PR TITLE
add command for fetching info about stock OS kernel from its repo

### DIFF
--- a/config/device/common/gen4.5pixel.yml
+++ b/config/device/common/gen4.5pixel.yml
@@ -3,7 +3,7 @@ platform:
     - device/google/sunfish-sepolicy
 
 includes:
-  - pixel.yml
+  - pixel-qcom.yml
 
 filters:
   dep_files:

--- a/config/device/common/gen4pixel.yml
+++ b/config/device/common/gen4pixel.yml
@@ -3,7 +3,7 @@ platform:
     - device/google/coral-sepolicy
 
 includes:
-  - pixel.yml
+  - pixel-qcom.yml
 
 device:
   build_id: TP1A.221005.002.B2

--- a/config/device/common/gen5pixel.yml
+++ b/config/device/common/gen5pixel.yml
@@ -3,7 +3,7 @@ platform:
     - device/google/redbull-sepolicy
 
 includes:
-  - pixel.yml
+  - pixel-qcom.yml
 
 filters:
   files:

--- a/config/device/common/pixel-qcom.yml
+++ b/config/device/common/pixel-qcom.yml
@@ -1,0 +1,5 @@
+includes:
+  - pixel.yml
+
+device:
+  kernel_repo_url: https://android.googlesource.com/kernel/msm

--- a/config/device/common/pixel.yml
+++ b/config/device/common/pixel.yml
@@ -6,6 +6,7 @@ includes:
 device:
   vendor: google_devices
   system_fs_type: ext4
+  kernel_repo_url: https://android.googlesource.com/kernel/gs
 
   build_id: TQ3A.230805.001
   prev_build_id: TQ3A.230705.001

--- a/src/commands/get-kernel-info.ts
+++ b/src/commands/get-kernel-info.ts
@@ -1,0 +1,200 @@
+import { Command, flags } from '@oclif/command'
+import assert from 'assert'
+import chalk from 'chalk'
+import { existsSync, promises as fs } from 'fs'
+import { JSDOM } from 'jsdom'
+import path from 'path'
+import { DEVICE_CONFIG_FLAGS, loadDeviceConfigs } from '../config/device'
+import { DeviceImages, prepareFactoryImages } from '../frontend/source'
+
+import { loadBuildIndex } from '../images/build-index'
+import { DeviceImage } from '../images/device-image'
+import { maybePlural } from '../util/cli'
+import { updateMultiMap } from '../util/data'
+import { GitLsRemote } from '../util/git'
+import { spawnAsync } from '../util/process'
+
+export default class GetKernelInfo extends Command {
+  static description = 'get info about stock OS kernel: version, tag, branch, etc'
+
+  static flags = {
+    buildIds: flags.string({
+      char: 'b',
+      multiple: true,
+      default: ['cur'],
+    }),
+    ...DEVICE_CONFIG_FLAGS,
+  }
+
+  async run() {
+    let { flags } = this.parse(GetKernelInfo)
+    let devices = await loadDeviceConfigs(flags.devices)
+    let res = await prepareFactoryImages(await loadBuildIndex(), devices, flags.buildIds)
+
+    let commitMap = new Map<string, DeviceImages[]>()
+    let commitVersionMap = new Map<string, string>()
+
+    let kernelRepoLsRemote = new Map<string, Promise<GitLsRemote>>()
+
+    let kernelInfos: [Promise<KernelInfo>, DeviceImages][] = []
+
+    for (let deviceImages of res.values()) {
+      let kernelRepoUrl = deviceImages.factoryImage.deviceConfig.device.kernel_repo_url
+      if (!kernelRepoLsRemote.has(kernelRepoUrl)) {
+        kernelRepoLsRemote.set(kernelRepoUrl, GitLsRemote.get(kernelRepoUrl))
+      }
+
+      let dirs = ['vendor_dlkm/lib/modules', 'vendor/lib/modules']
+      for (let dir of dirs) {
+        let dirPath = path.join(deviceImages.unpackedFactoryImageDir, dir)
+        if (!existsSync(dirPath)) {
+          continue
+        }
+
+        const dirents = await fs.readdir(dirPath, { withFileTypes: true })
+
+        let moduleFile = dirents.find(de => {
+          return (
+            de.name.endsWith('.ko') &&
+            // has a different format of vermagic
+            !de.name.startsWith('fips')
+          )
+        })!.name
+
+        kernelInfos.push([getKernelInfoFromModule(path.join(dirPath, moduleFile)), deviceImages])
+      }
+    }
+
+    for (let [kiPromise, imageSet] of kernelInfos) {
+      let ki: KernelInfo = await kiPromise
+
+      let cur = commitVersionMap.get(ki.commit)
+      if (cur !== undefined) {
+        assert(cur === ki.version, ki.commit)
+      } else {
+        commitVersionMap.set(ki.commit, ki.version)
+      }
+
+      updateMultiMap(commitMap, ki.commit, imageSet)
+    }
+
+    let commitInfos: Promise<CommitInfo>[] = []
+    for (let [commit, deviceImages] of commitMap) {
+      let factory = deviceImages[0].factoryImage
+      let kernelRepoUrl = factory.deviceConfig.device.kernel_repo_url
+      commitInfos.push(getCommitInfo(kernelRepoUrl, kernelRepoLsRemote, commit))
+    }
+
+    let logSeparator = false
+
+    for (let i of await Promise.all(commitInfos)) {
+      if (logSeparator) {
+        this.log('=================================================================================\n')
+      } else {
+        logSeparator = true
+      }
+      let factory = commitMap.get(i.commit)!.map(i => i.factoryImage)
+      this.log(
+        chalk.bold(`${i.commit} (${commitVersionMap.get(i.commit)}): `) + getDeviceBuildIds(factory, flags.buildIds),
+      )
+
+      if (i.branches.length > 0) {
+        this.log(`HEAD of branch${maybePlural(i.branches, '', 'es')}:\n${i.branches.join('\n')}`)
+      }
+
+      if (i.tags.length > 0) {
+        this.log(`\nTag${maybePlural(i.tags)}:`)
+      } else {
+        this.log(`No tag for ${i.commit}`)
+      }
+
+      for (let tag of i.tags) {
+        this.log(`${tag.name} | ${tag.annotation}\n${tag.date} | ${tag.author}\n`)
+      }
+    }
+  }
+}
+
+interface CommitInfo {
+  commit: string
+  branches: string[]
+  tags: TagInfo[]
+}
+
+interface TagInfo {
+  name: string
+  annotation: string
+  date: string
+  author: string
+}
+
+interface KernelInfo {
+  version: string
+  commit: string
+}
+
+async function getKernelInfoFromModule(modulePath: string) {
+  let stdout = await spawnAsync('modinfo', ['--field=vermagic', modulePath])
+
+  let parts = stdout.split('-')
+  // console.log(parts)
+  let version = parts[0]
+
+  let commit: string
+  if (parts[1].startsWith('android')) {
+    commit = parts[3]
+  } else {
+    commit = parts[1]
+  }
+  assert(commit.length === 13)
+  assert(commit[0] === 'g')
+  commit = commit.substring(1)
+
+  return { version, commit } as KernelInfo
+}
+
+async function getCommitInfo(repoUrl: string, lsRemoteMap: Map<string, Promise<GitLsRemote>>, commit: string) {
+  let lsRemote = await lsRemoteMap.get(repoUrl)
+  assert(lsRemote !== undefined)
+
+  let tags = lsRemote.getTagsForCommit(commit)
+  let branches = lsRemote.getBranchesForCommit(commit)
+
+  let baseTagsUrl = repoUrl + '/+/refs/tags/'
+
+  let tagInfos = await Promise.all(tags.map(name => loadTagInfo(baseTagsUrl + name, name)))
+
+  return { commit, branches, tags: tagInfos } as CommitInfo
+}
+
+async function loadTagInfo(gitilesUrl: string, name: string) {
+  let resp = await fetch(gitilesUrl)
+  assert(resp.ok)
+
+  // neither git ls-remote nor gitiles APIs support retrieving tag annotation, parse HTML
+
+  let jsdom = new JSDOM(await resp.text())
+  let doc = jsdom.window.document
+
+  let tagAnnotation = doc.querySelector('body > div > div > pre:nth-child(3)') as HTMLPreElement
+  assert(tagAnnotation.textContent!.endsWith('\n'))
+
+  let annotation = tagAnnotation.textContent!.slice(0, -1)
+
+  let tagger = doc.querySelector(
+    'body > div > div > div:nth-child(2) > table > tbody > tr:nth-child(2)',
+  ) as HTMLTableRowElement
+
+  assert(tagger.cells[0].textContent === 'tagger')
+  let date = tagger.cells[2].textContent
+  let author = tagger.cells[1].textContent
+
+  return { name, annotation, date, author, } as TagInfo
+}
+
+function getDeviceBuildIds(images: DeviceImage[], buildIdsFromFlags: string[]) {
+  let hideBuildId = buildIdsFromFlags.length === 1 && buildIdsFromFlags[0] === 'cur'
+  return hideBuildId
+    ? images.map(c => c.deviceConfig.device.name).join(' ')
+    : images.map(c => `${c.deviceConfig.device.name} ${c.buildId}`).join(', ')
+}

--- a/src/config/device.ts
+++ b/src/config/device.ts
@@ -27,6 +27,7 @@ export interface DeviceConfig {
     vendor: string
     // file system type of OS partitions
     system_fs_type: FsType
+    kernel_repo_url: string
     build_id: string
     prev_build_id: string
     // ignored when undefined

--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -36,4 +36,18 @@ export class GitLsRemote {
 
     return result
   }
+
+  public getTagsForCommit(commit: string) {
+    return getKeysForCommit(this.tags, commit)
+  }
+
+  public getBranchesForCommit(commit: string) {
+    return getKeysForCommit(this.branches, commit)
+  }
+}
+
+function getKeysForCommit(map: Map<string, string>, value: string) {
+  return Array.from(map.entries())
+    .filter(entry => entry[1].startsWith(value))
+    .map(entry => entry[0])
 }


### PR DESCRIPTION
```
% adevtool get-kernel-info                            
6e771b230c52 (5.10.157): felix tangorpro lynx cheetah panther bluejay raven oriole
HEAD of branches:
refs/heads/android-gs-bluejay-5.10-android13-qpr3
refs/heads/android-gs-felix-5.10-android13-qpr3
refs/heads/android-gs-lynx-5.10-android13-qpr3
refs/heads/android-gs-pantah-5.10-android13-qpr3
refs/heads/android-gs-raviole-5.10-android13-qpr3
refs/heads/android-gs-tangorpro-5.10-android13-qpr3

Tags:
android-13.0.0_r0.112 | Android 13.0.0 Release 0.112 (TQ3A.230805.001,TQ3A.230805.001.A1,TQ3A.230805.001.A2,raven/oriole)
Mon Aug 07 14:38:36 2023 -0700 | Xin Li <delphij@google.com>

android-13.0.0_r0.113 | Android 13.0.0 Release 0.113 (TQ3A.230805.001/TQ3A.230805.001.A1/TQ3A.230805.001.A2,bluejay)
Mon Aug 07 14:47:11 2023 -0700 | Xin Li <delphij@google.com>

android-13.0.0_r0.114 | Android 13.0.0 Release 0.114 (TQ3A.230805.001,TQ3A.230805.001.A2,cheetah,panther)
Mon Aug 07 14:53:35 2023 -0700 | Xin Li <delphij@google.com>

android-13.0.0_r0.115 | Android 13.0.0 Release 0.115 (TQ3A.230805.001,TQ3A.230805.001.A3,lynx)
Mon Aug 07 15:06:00 2023 -0700 | Xin Li <delphij@google.com>

android-13.0.0_r0.116 | Android 13.0.0 Release 0.116 (TQ3A.230805.001.B1,tangorpro)
Mon Aug 07 16:33:02 2023 -0700 | Xin Li <delphij@google.com>

android-13.0.0_r0.117 | Android 13.0.0 Release 0.117 (TQ3C.230805.001.A3,TQ3C.230805.001.A4,TQ3C.230805.001.B2,felix)
Mon Aug 07 16:44:01 2023 -0700 | Xin Li <delphij@google.com>

=================================================================================

8728c337137c (4.19.269): barbet redfin bramble
HEAD of branch:
refs/heads/android-msm-redbull-4.19-android13-qpr3

Tags:
android-13.0.0_r0.102 | Android 13.0.0 release 0.102
Wed Jul 05 14:47:29 2023 -0700 | The Android Open Source Project <initial-contribution@android.com>

android-13.0.0_r0.111 | Android 13.0.0 Release 0.111 (TQ3A.230805.001,TQ3A.230805.001.A2,bramble/redfin/barbet)
Mon Aug 07 14:28:33 2023 -0700 | Xin Li <delphij@google.com>

=================================================================================

6ff6ddc33f7d (4.14.302): sunfish
HEAD of branch:
refs/heads/android-msm-sunfish-4.14-android13-qpr3

Tags:
android-13.0.0_r0.101 | Android 13.0.0 release 0.101
Wed Jul 05 14:46:07 2023 -0700 | The Android Open Source Project <initial-contribution@android.com>

android-13.0.0_r0.110 | Android 13.0.0 Release 0.110 (TQ3A.230805.001,TQ3A.230805.001.A2,sunfish)
Mon Aug 07 14:22:30 2023 -0700 | Xin Li <delphij@google.com>

=================================================================================

6ef255005cea (4.14.276): coral flame
HEAD of branches:
refs/heads/android-msm-coral-4.14-android13
refs/heads/android-msm-sunfish-4.14-android13

Tags:
android-13.0.0_r0.21 | Android 13.0.0 Release 0.21 (TP1A.221005.002.B2,coral/flame)
Mon Feb 06 14:54:08 2023 -0800 | The Android Open Source Project <initial-contribution@android.com>

android-13.0.0_r0.41 | Android 13.0.0 release 0.41
Mon Nov 07 22:14:01 2022 -0800 | The Android Open Source Project <initial-contribution@android.com>
```