### PR TITLE
bugfix: generatePrep() didn't clear extra_product_makefiles

### DIFF
--- a/src/commands/generate-prep.ts
+++ b/src/commands/generate-prep.ts
@@ -30,6 +30,10 @@ const doDevice = (
   useTemp: boolean,
 ) =>
   withTempDir(async tmp => {
+    // these makefiles are expected to reference proprietary files that are
+    // inaccessible during state collection build
+    config.platform.extra_product_makefiles = []
+
     // Prepare stock system source
     let wrapBuildId = buildId == undefined ? null : buildId
     let wrapped = await withSpinner('Extracting stock system source', spinner =>
@@ -126,10 +130,6 @@ export default class GeneratePrep extends Command {
           stockSrc = flags.stockSrc!
           buildId = flags.buildId
         }
-
-        // these makefiles are expected to reference proprietary files that are
-        // inaccessible during state collection build
-        config.platform.extra_product_makefiles = []
 
         await doDevice(config, stockSrc, buildId, flags.skipCopy, flags.useTemp)
       },


### PR DESCRIPTION
generatePrep() is called from the `collect-state --rebuild` command, which uses a different codepath than the `generate-prep` command.