### PR TITLE
Update prep build script with new "cur" release config alias

### DIFF
--- a/scripts/make-prep-build.sh
+++ b/scripts/make-prep-build.sh
@@ -3,5 +3,5 @@
 set -e
 source build/envsetup.sh
 export OFFICIAL_BUILD=true
-lunch ${1}-ap2a-user
+lunch ${1}-cur-user
 m


### PR DESCRIPTION
With https://github.com/GrapheneOS/platform_build_release/commit/3c74e759fa2140a355725072099f6ef20ae54447 now in development 14 branch, prepare build script with the aforementioned commit in mind.