### PR TITLE
collect-state: switch to using the optimized build target

### DIFF
--- a/scripts/make-state-collection-build.sh
+++ b/scripts/make-state-collection-build.sh
@@ -8,4 +8,4 @@ export OFFICIAL_BUILD=true
 export BUILD_DATETIME=1751155200
 export BUILD_NUMBER=2025062900
 lunch ${1}-cur-user
-m
+m adevtool-state-collection-inputs

--- a/src/commands/collect-state.ts
+++ b/src/commands/collect-state.ts
@@ -65,9 +65,12 @@ export default class CollectState extends Command {
           if (!allowOutReuse) {
             await spawnAsync('rm', ['-rf', path.join(OS_CHECKOUT_DIR, 'out')])
           }
-          let res = spawnSync(path.join(ADEVTOOL_DIR, 'scripts/make-prep-build.sh'), [config.device.name], {
+          let label = 'state collection build took'
+          console.time(label)
+          let res = spawnSync(path.join(ADEVTOOL_DIR, 'scripts/make-state-collection-build.sh'), [config.device.name], {
             stdio: 'inherit',
           })
+          console.timeEnd(label)
           assert(res.status === 0, `make-prep-build.sh failed, exit code ${res.status}`)
         }
 

--- a/src/commands/collect-state.ts
+++ b/src/commands/collect-state.ts
@@ -34,16 +34,15 @@ export default class CollectState extends Command {
       description: 'generate prep vendor module (same as generate-prep) and make an OS build before collecting state',
       default: false,
     }),
-    allowOutReuse: Flags.boolean({
-      description: 'if --rebuild is specified, do not remove out/ dir before making an OS build',
-      default: false,
+    disallowOutReuse: Flags.boolean({
+      description: 'if --rebuild is specified, remove out/ dir before making a state collection OS build',
     }),
     ...DEVICE_CONFIG_FLAGS,
   }
 
   async run() {
     let {
-      flags: { devices, outRoot, parallel, outPath, rebuild, allowOutReuse },
+      flags: { devices, outRoot, parallel, outPath, rebuild, disallowOutReuse },
     } = await this.parse(CollectState)
 
     let configs = await loadDeviceConfigs(devices)
@@ -62,7 +61,7 @@ export default class CollectState extends Command {
           let deviceImages = deviceImagesMap.get(getDeviceBuildId(config))
           assert(deviceImages !== undefined)
           await generatePrep(config, deviceImages.unpackedFactoryImageDir, config.device.build_id)
-          if (!allowOutReuse) {
+          if (disallowOutReuse) {
             await spawnAsync('rm', ['-rf', path.join(OS_CHECKOUT_DIR, 'out')])
           }
           let label = 'state collection build took'

--- a/src/commands/collect-state.ts
+++ b/src/commands/collect-state.ts
@@ -18,11 +18,6 @@ export default class CollectState extends Command {
 
   static flags = {
     help: Flags.help({ char: 'h' }),
-    aapt2: Flags.string({
-      char: 'a',
-      description: 'path to aapt2 executable',
-      default: 'out/host/linux-x86/bin/aapt2',
-    }),
     outRoot: Flags.string({ char: 'r', description: 'path to AOSP build output directory (out/)', default: 'out' }),
     parallel: Flags.boolean({
       char: 'p',
@@ -48,7 +43,7 @@ export default class CollectState extends Command {
 
   async run() {
     let {
-      flags: { aapt2: aapt2Path, devices, outRoot, parallel, outPath, rebuild, allowOutReuse },
+      flags: { devices, outRoot, parallel, outPath, rebuild, allowOutReuse },
     } = await this.parse(CollectState)
 
     let configs = await loadDeviceConfigs(devices)
@@ -76,7 +71,7 @@ export default class CollectState extends Command {
           assert(res.status === 0, `make-prep-build.sh failed, exit code ${res.status}`)
         }
 
-        let state = await collectSystemState(config.device.name, outRoot, aapt2Path)
+        let state = await collectSystemState(config.device.name, outRoot)
 
         // Write
         let devicePath = isDir ? `${outPath}/${config.device.name}.json` : outPath

--- a/src/commands/collect-state.ts
+++ b/src/commands/collect-state.ts
@@ -78,6 +78,7 @@ export default class CollectState extends Command {
         // Write
         let devicePath = isDir ? `${outPath}/${config.device.name}.json` : outPath
         await fs.writeFile(devicePath, serializeSystemState(state))
+        this.log(`written serialized build state to ${devicePath}`)
       },
       c => c.device.name,
     )

--- a/src/commands/generate-all.ts
+++ b/src/commands/generate-all.ts
@@ -77,7 +77,7 @@ const doDevice = (
     }
 
     // customSrc can point to a (directory containing) system state JSON or out/
-    let customState = await loadCustomState(config, aapt2Path, customSrc)
+    let customState = await loadCustomState(config, customSrc)
 
     // Each step will modify this. Key = combined part path
     let namedEntries = new Map<string, BlobEntry>()

--- a/src/config/system-state.ts
+++ b/src/config/system-state.ts
@@ -103,19 +103,11 @@ export async function collectSystemState(device: string, outRoot: string) {
     }
   }
 
-  // Props
-  state.partitionProps = await withSpinner('Extracting properties', () => loadPartitionProps(systemRoot))
-
+  state.partitionProps = await loadPartitionProps(systemRoot)
   // SELinux contexts
-  state.partitionSecontexts = await withSpinner('Extracting SELinux contexts', () => parsePartContexts(systemRoot))
-
-  // vintf info
-  state.partitionVintfInfo = await withSpinner('Extracting vintf manifests', () => loadPartVintfInfo(systemRoot))
-
-  // Module info
-  state.moduleInfo = await withSpinner('Parsing module info', async () =>
-    parseModuleInfo(await readFile(moduleInfoPath)),
-  )
+  state.partitionSecontexts = await parsePartContexts(systemRoot)
+  state.partitionVintfInfo = await loadPartVintfInfo(systemRoot)
+  state.moduleInfo = parseModuleInfo(await readFile(moduleInfoPath))
 
   return state
 }

--- a/src/config/system-state.ts
+++ b/src/config/system-state.ts
@@ -65,7 +65,7 @@ export function parseSystemState(json: string) {
   return diskState as SystemState
 }
 
-export async function collectSystemState(device: string, outRoot: string, aapt2Path: string) {
+export async function collectSystemState(device: string, outRoot: string) {
   let systemRoot = `${outRoot}/target/product/${device}`
   let moduleInfoPath = `${systemRoot}/module-info.json`
   let state = {

--- a/src/frontend/devices.ts
+++ b/src/frontend/devices.ts
@@ -10,10 +10,7 @@ export async function forEachDevice<Device>(
   let isMultiDevice = devices.length > 1
   for (let device of devices) {
     if (isMultiDevice) {
-      console.log(`
-
-${chalk.bold(chalk.blueBright(deviceKey(device)))}
-`)
+      console.log(`${chalk.bold(chalk.blueBright(deviceKey(device)))}`)
     }
 
     let job = callback(device)

--- a/src/frontend/generate.ts
+++ b/src/frontend/generate.ts
@@ -37,7 +37,7 @@ export interface PropResults {
   missingOtaParts: Array<string>
 }
 
-export async function loadCustomState(config: DeviceConfig, aapt2Path: string, customSrc: string) {
+export async function loadCustomState(config: DeviceConfig, customSrc: string) {
   if ((await fs.stat(customSrc)).isFile()) {
     return parseSystemState(await readFile(customSrc))
   }
@@ -48,7 +48,7 @@ export async function loadCustomState(config: DeviceConfig, aapt2Path: string, c
   }
 
   // Otherwise, assume it's AOSP build output
-  return await collectSystemState(config.device.name, customSrc, aapt2Path)
+  return await collectSystemState(config.device.name, customSrc)
 }
 
 export async function enumerateFiles(


### PR DESCRIPTION
Using the optimized build target reduces the state collection build time from ~50 minutes to ~2.5
minutes on my machine.
Large part of the state collection build time is now spent in single-threaded code, i.e. running
multiple state collection builds in parallel will yield significant speedups.

Depends on https://github.com/GrapheneOS/platform_build/pull/74