### PR TITLE
unpackExt4: ignore e2fsprogs debugfs chown/fchown EINVAL errors too

### DIFF
--- a/src/frontend/source.ts
+++ b/src/frontend/source.ts
@@ -520,6 +520,8 @@ async function unpackExt4(fsImagePath: string, destinationDir: string) {
       // it's expected that ownership information will be lost during unpacking
       s.startsWith('dump_file: Operation not permitted while changing ownership of ') ||
       s.startsWith('rdump: Operation not permitted while changing ownership of ') ||
+      s.startsWith('rdump: Invalid argument while changing ownership of ') ||
+      s.startsWith('dump_file: Invalid argument while changing ownership of ') ||
       // version string
       s.startsWith('debugfs ')
     )


### PR DESCRIPTION
Currently, `unpackExt4` ignores `EPERM` ("Operation not permitted") errors thrown by the `fchown` and `chown` calls in the `e2fsprogs` `debugfs` binary (located in `debugfs/dump.c`, function `fix_perms`), as it is expected that the user running `adevtool` is not root, and the exact permissions of the extracted files are irrelevant.

However, if `adevtool` is being run in a user namespace in which the UIDs and GIDs of the files in the ext4 image are not mapped yet, `fchown` and `chown` will return `EINVAL` ("Invalid argument"), which previously made `adevtool` crash. This patch adds the possible `EINVAL` error messages to the list of ignored stderr output lines.