### PR TITLE
update README.md as video doesn't exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Android device support and bringup tool, designed for maximum automation and speed.
 
-[![Demo video on asciinema](https://asciinema.org/a/kCWUN6XcyaDEU6bcoE65rVQrv.svg)](https://asciinema.org/a/kCWUN6XcyaDEU6bcoE65rVQrv)
-
 ## Features
 
 This tool automates the following tasks for devices that mostly run AOSP out-of-the-box (e.g. Google Pixel):

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,10 +8,6 @@ All commands that accept stock system images, with the exception of comparison c
 
 Given a device codename, vendor name, stock system source, and LineageOS proprietary-files.txt list, extract proprietary files and generate build files.
 
-Speed comparison with LineageOS extract-utils:
-
-[![Speed comparison with LineageOS extract-utils](https://asciinema.org/a/eUMNIrKtBrln1CwE1zCUnJO8w.svg)](https://asciinema.org/a/eUMNIrKtBrln1CwE1zCUnJO8w)
-
 <details>
 <summary>Command-line help</summary>
 


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` documentation by removing the demo video badge. This change streamlines the readme and removes the embedded link to the demo video.