### PR TITLE
Backport WiFi APEX

### DIFF
--- a/src/build/hardcoded-backport-config.ts
+++ b/src/build/hardcoded-backport-config.ts
@@ -110,6 +110,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V4-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
       "vendor/lib64/libedgetpu_litert.so",
@@ -201,6 +203,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V4-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
       "vendor/lib64/libedgetpu_litert.so",
@@ -291,6 +295,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V4-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
       "vendor/lib64/libedgetpu_litert.so",
@@ -381,6 +387,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V4-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
       "vendor/lib64/libedgetpu_litert.so",
@@ -469,6 +477,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V4-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
       "vendor/lib64/libedgetpu_litert.so",
@@ -558,6 +568,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V4-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
       "vendor/lib64/libedgetpu_litert.so",
@@ -646,6 +658,7 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
 
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
       "vendor/lib64/libedgetpu_litert.so",
@@ -731,6 +744,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V4-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
       "vendor/lib64/libedgetpu_litert.so",
@@ -815,6 +830,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V3-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
     ],
@@ -854,6 +871,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "vendor/lib64/libedgetpu_util.so",
       "system_ext/lib64/com.google.edgetpu_app_service-V3-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
     ],
@@ -936,6 +955,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V3-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
     ],
@@ -1019,6 +1040,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V3-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
     ],
@@ -1102,6 +1125,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V3-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
     ],
@@ -1144,6 +1169,7 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/priv-app/EuiccSupportPixelPermissions/EuiccSupportPixelPermissions.apk",
       "system_ext/priv-app/OemRilService/OemRilService.apk",
       "vendor/apex/com.google.pixel.euicc.update.apex",
+
       "vendor/bin/hw/rild_exynos",
       "vendor/bin/hw/vendor.google.radioext@1.0-service",
       "vendor/lib64/com.google.pixel.modem.logmasklibrary-V1-ndk.so",
@@ -1177,6 +1203,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V3-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
       "vendor/firmware/brcm/BTFW_D.hcd",
@@ -1253,6 +1281,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V3-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
       "vendor/firmware/brcm/BTFW_D.hcd",
@@ -1329,6 +1359,8 @@ export const deviceBackportConfig: Record<string, BackportConfig> = {
       "system_ext/lib64/com.google.edgetpu_app_service-V3-ndk.so",
       "system_ext/lib64/com.google.edgetpu_vendor_service-V2-ndk.so",
       "vendor/bin/hw/vendor.google.edgetpu_vendor_service@1.0-service",
+
+      "vendor/apex/com.google.pixel.wifi.ext.apex",
     ],
     newFiles: [
       "vendor/firmware/brcm/BTFW_D.hcd",

--- a/vendor-specs/google_devices/akita.yml
+++ b/vendor-specs/google_devices/akita.yml
@@ -2713,7 +2713,7 @@ proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 3c008a219e5bd309921dc5e92abc6b715cce8f1fca1df2475749c8865eda031c
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 1020d26646a8893e876f598efac1c0b6bb23a3e8f2ea8d00d7a571c8b50021fb
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: f48ce981126265b37aa0d550fd648efb0b824f498bfa54898b18c760f44a8258
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 3428b7a9764f678f2baaa90e40f751fcbda3d68b6cebb7e8ec80bb8bf9cead3f
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 67d8778caf11486a3b18216e2a08ac4e3f82da3e04a340af08351ec50e07e5d1
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: a43df4e322d4d841bd6049508ae4038fa7857666c67dc003f35a63dca2203026
 proprietary/vendor/bin/aocxd: 8bf26b993061331c3768adae16e5cbf46c50be38ef7234fddcabffd2044caeaa

--- a/vendor-specs/google_devices/bluejay.yml
+++ b/vendor-specs/google_devices/bluejay.yml
@@ -2840,7 +2840,7 @@ proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 07f053105b5192ba2c8f276b3a3a41f16d5143379a53ed73b5722cb6c805c63c
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 79e68371661db695d76f3729e3f8d643e79a0e0d3645e97092071aabf2ac6277
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: e5848ea834d789b94f8b64cb18e4e612712ac4da5f8b3b617f05a85e1bed9535
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: b6bd6ebaf1a6843c4785bf8ee255b4c474e1477dec4ec5bea7b20aa5b9a3fa12
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 73a7f63a4a6ab1b4597548edc45272e7fc91acdb5f18aede222c627b6144fd3a
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: 98a33da6e3de973f68e99a0783998ab432b8f6f91e760bf27231a40a555d0570
 proprietary/vendor/bin/aocxd: 96988bb3069ab36436d7538e3a49df72711024808e97bdaf1af3a395a2e19267

--- a/vendor-specs/google_devices/caiman.yml
+++ b/vendor-specs/google_devices/caiman.yml
@@ -2920,7 +2920,7 @@ proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 754de2eac6fbcc212490b418f872b248aee8b9ac470e33e0471bb0de4980e558
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 2018afc8793db2eb84d16c57f3d9d8467621d2b0c3e59b447fa3f110af000fc4
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 4ef797ae66e7a9ee0a407ec8aaf8862ac2aff6fb423aed157447726c1455fe69
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 65eb0d1bdcebc721b9385b59c052a1c261cbe5f9f89ef57b8e771ca75a393a78
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: c78c7aff84073c8d93b4374b3e46df42486bc55b37af1181b457e6579e6780a1
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: a43df4e322d4d841bd6049508ae4038fa7857666c67dc003f35a63dca2203026
 proprietary/vendor/bin/aocxd: 8bf26b993061331c3768adae16e5cbf46c50be38ef7234fddcabffd2044caeaa

--- a/vendor-specs/google_devices/cheetah.yml
+++ b/vendor-specs/google_devices/cheetah.yml
@@ -3156,7 +3156,7 @@ proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 0e612ed75e3fe80cff8e36d3906f4533683576a3a0d9b4d66c0e9c096044a712
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 826946a230b7d402de58ddfcc816942bcd6e6e12c79e9652c4c96c8ca65e0cc1
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 89a97ce13da2a789b71039e22ce56056dafa08a48ce257e8715fba9f58791683
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: c5430d61fda40e7441026bcc39596660d71e53be005f1bc9a07f41765b9a58f5
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 274eddade7863e8748aef07ce9b20d75d7d3191f2f8e978c49cec96551b7b61a
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: 98a33da6e3de973f68e99a0783998ab432b8f6f91e760bf27231a40a555d0570
 proprietary/vendor/bin/aocxd: 96988bb3069ab36436d7538e3a49df72711024808e97bdaf1af3a395a2e19267

--- a/vendor-specs/google_devices/comet.yml
+++ b/vendor-specs/google_devices/comet.yml
@@ -3054,7 +3054,7 @@ proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 82a9e1683466286346ef61198fe8acb2e7649282c83974eb24cfda56d1b9abfc
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: a09bc65c208d706c3de214f48bcf390b9a7f5ff09c7c8e9e2d156e72e14ac2bc
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 61797d9aa168133e1a86329c57a9a31a211126532a7abafdef5e3b56ed58e046
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 6820bba5247aa947fcd52b0317fc9f3be85034d54d55237edc6c356ab2de4a48
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: caf74c49499beb6a9ba11f78136aaf02fdeab032a2305c63e22213b4b7e84388
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: a43df4e322d4d841bd6049508ae4038fa7857666c67dc003f35a63dca2203026
 proprietary/vendor/bin/aocxd: 8bf26b993061331c3768adae16e5cbf46c50be38ef7234fddcabffd2044caeaa

--- a/vendor-specs/google_devices/felix.yml
+++ b/vendor-specs/google_devices/felix.yml
@@ -3803,7 +3803,7 @@ proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: b14e9475714b2f5b78fb8341efc473758cccb2185abfc53a604750d17506a7d2
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 1dde2e880d100a8c958a45a42922a6d6cef1ffd786b45cc0750ee329e8a27952
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 9159689b25f07450440b1a33f4e2f0f68a1f7239647ff53871347dcd7f14d29f
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 278a027a9c87df2f498196fc1bd24dcc17cf2fc0c27057243e9fa79a7b2a170a
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: e2302974e1467ccf597fa9d4c3e985ae49a69d1e55298ad0122fd1a8b6ee2ad1
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: 98a33da6e3de973f68e99a0783998ab432b8f6f91e760bf27231a40a555d0570
 proprietary/vendor/bin/aocxd: 96988bb3069ab36436d7538e3a49df72711024808e97bdaf1af3a395a2e19267

--- a/vendor-specs/google_devices/husky.yml
+++ b/vendor-specs/google_devices/husky.yml
@@ -2703,7 +2703,7 @@ proprietary/vendor/apex/com.google.android.hardware.biometrics.fingerprint.apex:
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 690513a869688bf1f2d4167c73c7b0e57c4a75e798318af0e79d9ae4c7d6ae55
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: d111e291f07d5bb3ab93534e6882e6157525ba654f2334a489cd9e4f8d930524
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 464b8838e479b3eef9dc11a09bab3741d819d293f788e041f2e3ba3ba55cfcd9
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 55058186fdbd8289fd6139e0907d7e37f65c62157e7a8462b34dc99725f3b534
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 836f8c0fef285680dc9c260e4916250dcb0ae9b4657d815666cb87d09c57ecd8
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: a43df4e322d4d841bd6049508ae4038fa7857666c67dc003f35a63dca2203026
 proprietary/vendor/bin/aocxd: 8bf26b993061331c3768adae16e5cbf46c50be38ef7234fddcabffd2044caeaa

--- a/vendor-specs/google_devices/komodo.yml
+++ b/vendor-specs/google_devices/komodo.yml
@@ -2921,7 +2921,7 @@ proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 3a4dd36122568d02869d02f9ef769853ec4eed35a020cfca7c708d43ce21f61b
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 61d2e2d606019e4dd93456aa9d3a402d70b8dd10db339333180c2386504c3968
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: c72722d4c0994f59494cccbf79e83144a14eecb6ea6afd6a3bce2c058702b46f
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 96d4e2957c2d704f58cb5b4b5efb86d8ce3753c2adc4ab7ef0df63d1650162b7
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: b3f4b7706876b966956c4601575856a70aae414a58ce00b116bf9eae07427bf8
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: a43df4e322d4d841bd6049508ae4038fa7857666c67dc003f35a63dca2203026
 proprietary/vendor/bin/aocxd: 8bf26b993061331c3768adae16e5cbf46c50be38ef7234fddcabffd2044caeaa

--- a/vendor-specs/google_devices/lynx.yml
+++ b/vendor-specs/google_devices/lynx.yml
@@ -2730,7 +2730,7 @@ proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 8a3dde3c3f4c28fc24ecbfb8c79ea2dfc2844d845c2c6879bfaa38fe89925b06
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: b7926a0e22e7f43801f3d0a7424615e07269dd3b821bd3eef27fefedafad0c83
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 9a2e46cc26bbb02557d29ad5fd791d6ae431b10d32c19122b645b4befff20838
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 0023e19adc00461e987623294231c0c19d2c010fcb169b9166e19bb111cff6de
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 4a144cd891499504d7a81b7b79c4f6957f2fee043a604e8b0be519ca719d4c03
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: 98a33da6e3de973f68e99a0783998ab432b8f6f91e760bf27231a40a555d0570
 proprietary/vendor/bin/aocxd: 96988bb3069ab36436d7538e3a49df72711024808e97bdaf1af3a395a2e19267

--- a/vendor-specs/google_devices/oriole.yml
+++ b/vendor-specs/google_devices/oriole.yml
@@ -2828,7 +2828,7 @@ proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 1525b55f3f45071b44e09e11f85804074ed2caa700327e53dd5c99fb67e64204
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: ccf9ca33fa400fd730f980103df8f9446a75eac3c5c32f56e8e9ad141fb6b3c8
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: d2033b78703e0d42d71d06703844fa61cb45957c5f489fdbf1fa0cd313a34740
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: a214e852e251b521cc50c88dc57316db4a0d1d69c5e9b519b07806682dafa331
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 56cd7d0f0e05845bb5461e09180416a69a0e8233ed2f7086561ca7778ee1e43e
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: 98a33da6e3de973f68e99a0783998ab432b8f6f91e760bf27231a40a555d0570
 proprietary/vendor/bin/aocxd: 96988bb3069ab36436d7538e3a49df72711024808e97bdaf1af3a395a2e19267

--- a/vendor-specs/google_devices/panther.yml
+++ b/vendor-specs/google_devices/panther.yml
@@ -3180,7 +3180,7 @@ proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 70b1a8664ad44391e857b9d678ee554f777424c31d3714863ab8316de3cece77
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: a662be0a570ac5d4a3831fb0e0b1575ce7b29493d69fe638dc19945a91100b2e
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: aeb60d427ccf94ae27f7c323ef6e512ad69ebdeca934cbfbe4016b5fb5569f35
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 5418846afc4630d0405df04bef7aead5c15722b416a14112aeb7b174b36f0272
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 2dfdcb0fb4711573ef9df6e86aaec97cb025194f79cf72f50bf08af2d9f26d7a
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: 98a33da6e3de973f68e99a0783998ab432b8f6f91e760bf27231a40a555d0570
 proprietary/vendor/bin/aocxd: 96988bb3069ab36436d7538e3a49df72711024808e97bdaf1af3a395a2e19267

--- a/vendor-specs/google_devices/raven.yml
+++ b/vendor-specs/google_devices/raven.yml
@@ -3001,7 +3001,7 @@ proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 0f9e0b6f58bfb7bf50cac17c72a9ae5fa1465f5584f4db824b3eccb4d7f6607b
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 3638d5cbe3e93c0a22962c3dc3e5ecd12321b47169f9ada2fcb0fb5e65a1f5d0
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 6418d5997aedceb852c93f13c03e756ac2dec0c3085375f19c2d689f6c0be04d
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 72dc217c39e25e42b9bd5395dd187ace6e0bd1236841e7222f9ed36fad692a82
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: ff5d0eab6515fdbf45a77dc1832652e11a57e0d72f568e61a630fd7ed16b6f23
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: 98a33da6e3de973f68e99a0783998ab432b8f6f91e760bf27231a40a555d0570
 proprietary/vendor/bin/aocxd: 96988bb3069ab36436d7538e3a49df72711024808e97bdaf1af3a395a2e19267

--- a/vendor-specs/google_devices/shiba.yml
+++ b/vendor-specs/google_devices/shiba.yml
@@ -2691,7 +2691,7 @@ proprietary/vendor/apex/com.google.android.hardware.biometrics.fingerprint.apex:
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: a1d8cd321dcf019d60a1f4175169c53a770c17a182794b574ffdc8b3ab1bfb37
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 79b006684c00ec81f7671ca198ed6a880fd1e05c84698fd57748e692982b8668
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: c221157ad6e67b1c9a4f0be08532b30199d08f93204931c55f902980f711e4a6
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 5a6c907a2a229e5356fe966b58a2bb0b01eb263233719bee2fe949e910771087
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 49ca4c7f1de333da74142d51cf3ff361e5114f2b0876c6d42a2fe8187553116a
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: a43df4e322d4d841bd6049508ae4038fa7857666c67dc003f35a63dca2203026
 proprietary/vendor/bin/aocxd: 8bf26b993061331c3768adae16e5cbf46c50be38ef7234fddcabffd2044caeaa

--- a/vendor-specs/google_devices/tangorpro.yml
+++ b/vendor-specs/google_devices/tangorpro.yml
@@ -4707,7 +4707,7 @@ proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: ae83b602c39aae29462d63e7c5f5cfac437a1327f108311e43b197da1b0ba1e8
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 929cc1f6fa0ffe12290374bbaef5abde73b6366ab92792ae971b0343503093ac
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 8c18bc63119d5d53e5e518d2e28400386010888110b2cc230c8c9cba40f6935a
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: d934c3b1a45412c7f4d6ea95cab58c4f0ff8bf40b63fb204c402d1240eb62c49
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: 98a33da6e3de973f68e99a0783998ab432b8f6f91e760bf27231a40a555d0570
 proprietary/vendor/bin/aocxd: 325d0530569dce1a0b9bab488e4f879cc9ccd770c8f323020642fdd7072b9a46

--- a/vendor-specs/google_devices/tegu.yml
+++ b/vendor-specs/google_devices/tegu.yml
@@ -2731,7 +2731,7 @@ proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 9955693cc9d35a26660991427a871ffeca5d747ce03ea9fddd2958c87a157f15
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 883bd530ef1a36c2f64017e1186dcfac23131fa1a3b8ae2b5dcf8cbe4c72c823
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: ec855d6e05a5d6455234e716b79a4294a7ecb29a60f346fae95110b8917cd869
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 53bb7e16c3a2ebd2ee5b82d863c398df0e0c7925f31efd5221f0be98ebffea53
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: b5c06a5dce337d680a24d244313b9f952d27b645cde1d041df732b338236a72d
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: a43df4e322d4d841bd6049508ae4038fa7857666c67dc003f35a63dca2203026
 proprietary/vendor/bin/aocxd: 8bf26b993061331c3768adae16e5cbf46c50be38ef7234fddcabffd2044caeaa

--- a/vendor-specs/google_devices/tokay.yml
+++ b/vendor-specs/google_devices/tokay.yml
@@ -2910,7 +2910,7 @@ proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 23b1f232cdc2020d14ed1b2ee49dbf4631ec4ae09b72f332ca08a00f0f7091f8
 proprietary/vendor/apex/com.google.pixel.camera.hal.apex: ee2c0e0809082df03659768a4b85c050466a300da4683fc71ecdadd17a0938c7
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 8b20e697341f951b58d4af4e471e5231bd9c6ed6e801638103046f463da75b30
-proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: c9813c008d7caeb5279c0e5a07cf885c900443e711f32134ababfafba85b51ea
+proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 63e1fcb9f6e2f508b3bfa86a559ce1b9747d9480715a91c1390442685ce54374
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: a43df4e322d4d841bd6049508ae4038fa7857666c67dc003f35a63dca2203026
 proprietary/vendor/bin/aocxd: 8bf26b993061331c3768adae16e5cbf46c50be38ef7234fddcabffd2044caeaa


### PR DESCRIPTION
Reset to https://github.com/GrapheneOS/adevtool/commit/3ec73e5969f83d4dd62ea8d92e63719f09754002

This amends commit messages, in addition to backporting WiFi APEX across all devices.