### PR TITLE
add synthetic overlay for auto data switch enabling cross SIM calling

### DIFF
--- a/config/device/common/overlay-inclusion.yml
+++ b/config/device/common/overlay-inclusion.yml
@@ -693,6 +693,7 @@ filters:
       - com.android.settings:array/when_to_start_screensaver_values_no_battery|*
       - com.android.settings:bool/config_adaptive_alert_vibration_enabled = true
       - com.android.settings:bool/config_adaptive_touch_sensitivity_enabled = true
+      - com.android.settings:bool/config_auto_data_switch_enables_cross_sim_calling|*
       - com.android.settings:bool/config_battery_first_use_date_enabled = false
       - com.android.settings:bool/config_clear_calling_enabled = false
       - com.android.settings:bool/config_clear_calling_enabled = true

--- a/config/device/common/synthetic-overlays.yml
+++ b/config/device/common/synthetic-overlays.yml
@@ -5,6 +5,7 @@ synthetic_overlays:
     targetPackage: com.android.settings
     resourcesToInclude:
       bool:
+        - config_auto_data_switch_enables_cross_sim_calling
         - config_show_smooth_display
         - config_show_touch_sensitivity
       integer:


### PR DESCRIPTION
unable to generate specs/skels for all devices

Before this patch, turning on Automatic data switching in Settings with dual SIMs gives these log lines via `adb logcat -b radio -e "CrossSim"` for a carrier that supports it:

```
D ImsManagerIM [0]: isCrossSimCallingEnabled: platformEnabled = true, provisioned = true, userEnabled = false
```

`userEnabled = false` because the Settings app is not configured to enable cross SIM calling without this override. The ViewModel in the Settings app will never get a chance to actually set cross SIM calling enabled:

https://github.com/GrapheneOS/platform_packages_apps_Settings/blob/16/src/com/android/settings/network/telephony/wificalling/CrossSimCallingViewModel.kt#L60