### PR TITLE
Add resources for Pixel 10 series high EMF (PWM) mode setting

### DIFF
--- a/config/device/common/gen10pixel.yml
+++ b/config/device/common/gen10pixel.yml
@@ -306,7 +306,6 @@ filters:
       - com.android.settings:raw/udfps_edu_lottie|*
       - com.android.settings:string/doze_always_on_wallpaper_description|*
       - com.android.settings:string/doze_always_on_wallpaper_title|*
-      - com.android.settings:string/emission_frequency_summary|*
       - com.android.settings:string/frr_notification_reset_fingerprint_description|*
       - com.android.systemui:array/config_doze_brightness_sensor_to_wallpaper_scrim_opacity = -1;51;0;0;0
       - com.android.systemui:bool/config_minmode_enabled = true

--- a/config/device/common/overlay-inclusion.yml
+++ b/config/device/common/overlay-inclusion.yml
@@ -869,6 +869,8 @@ filters:
       - com.android.settings:string/dream_secondary_button_title|*
       - com.android.settings:string/edge_to_edge_navigation_summary|*
       - com.android.settings:string/enable_glanceable_hub_toggle_summary|*
+      - com.android.settings:string/emission_frequency_summary|*
+      - com.android.settings:string/emission_frequency_title|*
       - com.android.settings:string/fast_pair_device_not_found_other_device_description|*
       - com.android.settings:string/fast_pair_device_not_found_tws_headphone_description|*
       - com.android.settings:string/fingerprint_acquired_imager_dirty_udfps|*

--- a/config/device/common/synthetic-overlays.yml
+++ b/config/device/common/synthetic-overlays.yml
@@ -27,6 +27,8 @@ synthetic_overlays:
         - charging_optimization_reach_limit_charge_label
         - charging_optimization_reach_limit_remaining_time_label
         - charging_optimization_remaining_time_label
+        - emission_frequency_summary
+        - emission_frequency_title
         - help_uri_5g_dsds
         - help_uri_about
         - help_uri_about_phone_v2


### PR DESCRIPTION
Part of: https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/390

---

The SettingsGoogle string resources are included in the stock OS for every Pixel model since the 6 series. `config_availableEMValueOptions` actually exists in AOSP (https://github.com/GrapheneOS/platform_frameworks_base/commit/644b6491408f2ab5a1c9558d1c452cb747c4469b), but is unused in AOSP Settings. blazer, mustang, and rango have device specific overlays in the stock OS to override the option to [0, 1], which actually enables the feature.

---

I put the two string resources in the common files since the corresponding code in `packages/apps/Settings` gets built for every device. `config_availableEMValueOptions` is left in `gen10pixel.yml` since only the Pixel 10 series enable the feature.

I downloaded the latest stock OS release for all 20 devices from the Pixel 6 series through the Pixel 10 series and confirmed that the resources are present in all of them.