### PR TITLE
lynx: fix wifi regression

### DIFF
--- a/src/blobs/copy.ts
+++ b/src/blobs/copy.ts
@@ -74,6 +74,8 @@ async function maybePatch(entry: BlobEntry, srcPath: string) {
           return patchGpsXml(await readFile(srcPath))
         case 'etc/gnss/gps.cfg':
           return patchGpsCfg(await readFile(srcPath))
+        case 'firmware/wlan/qcom_cfg.ini':
+          return patchWlanConfig(await readFile(srcPath))
       }
       if (relPath.startsWith('etc/fstab')) {
         return patchFstab(await readFile(srcPath))
@@ -190,6 +192,15 @@ function patchGpsCfg(orig: string) {
       return line
     }
   })
+}
+
+function patchWlanConfig(orig: string) {
+  return replaceLines(orig, line => {
+    if (line.startsWith('gActiveUcBpfMode=')) {
+      return '';
+    }
+    return line;
+  }).replace(/\n\n+/g, '\n')
 }
 
 function replaceLines(multiLine: string, callbackFn: (value: string) => string) {


### PR DESCRIPTION
### Problem

The Pixel 7a (lynx) QPR2 vendor blobs contain `gActiveUcBpfMode=1` in the WLAN configuration, which enables Android Packet Filter (APF) for all unicast traffic in active mode. This leads to a severe wifi throughput regression as the filter processes every incoming packet.

This setting appears to be unique to lynx, as other WCN6740 devices (panther, cheetah, felix, tangorpro) do not have it (I checked each device's latest factory image). Google has also removed this from the Pixel rom for lynx.

### Solution

I've added a patch to `vendor/firmware/wlan/qcom_cfg.ini` to remove the `gActiveUcBpfMode=1` line.

### Testing

I tested this on my own Pixel 7a and can confirm that the WiFi speeds are as expected, I was getting 13mbps before the patch, and 400mbps after.