### PR TITLE
disable NTP usage in Samsung gnssd; extend init-time checks in adevtool launcher

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -7,6 +7,11 @@ if (NODE_MAJOR_VERSION < MIN_NODE_MAJOR_VERSION) {
   throw new Error(`This tool requires NodeJS ${MIN_NODE_MAJOR_VERSION} or later`)
 }
 
+if (process.getuid() === 0) {
+  // some dependencies (e.g. cpio, debugfs) behave differently when they run as root
+  throw new Error('running adevtool as root is not supported')
+}
+
 const expectedPathEnding = '/vendor/adevtool/bin/run'
 let cwd = process.cwd()
 let validCwd = false

--- a/bin/run
+++ b/bin/run
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const { statSync } = require('node:fs')
 const NODE_MAJOR_VERSION = process.versions.node.split('.')[0]
 const MIN_NODE_MAJOR_VERSION = 24
 
@@ -31,7 +32,15 @@ if (!validCwd) {
   process.exit(1)
 }
 
-process.env.PATH = cwd + '/prebuilts/build-tools/path/linux-x86:' + cwd + '/prebuilts/jdk/jdk21/linux-x86/bin:' + process.env.PATH
+let extraPathDirs = [cwd + '/prebuilts/build-tools/path/linux-x86', cwd + '/prebuilts/jdk/jdk21/linux-x86/bin']
+for (let dir of extraPathDirs) {
+  let stat = statSync(dir, { throwIfNoEntry: false })
+  if (stat === undefined || !stat.isDirectory()) {
+    throw new Error('missing prebuilts dir: ' + dir)
+  }
+}
+
+process.env.PATH = extraPathDirs.join(':') + ':' + process.env.PATH
 
 process.env.UV_THREADPOOL_SIZE = require('os').cpus().length.toString()
 

--- a/bin/run
+++ b/bin/run
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
 const NODE_MAJOR_VERSION = process.versions.node.split('.')[0]
+const MIN_NODE_MAJOR_VERSION = 24
 
-if (NODE_MAJOR_VERSION < 18) {
-  throw new Error('This tool requires NodeJS 18 or later')
+if (NODE_MAJOR_VERSION < MIN_NODE_MAJOR_VERSION) {
+  throw new Error(`This tool requires NodeJS ${MIN_NODE_MAJOR_VERSION} or later`)
 }
 
 const expectedPathEnding = '/vendor/adevtool/bin/run'

--- a/config/build-index/build-index-beta.yml
+++ b/config/build-index/build-index-beta.yml
@@ -344,3 +344,60 @@ mustang CP11.251114.007:
 rango CP11.251114.007:
   factory: 7c5f6c20bce4389f13198938c691368f2746083d3cb92add75f507e71c31af1a https://dl.google.com/developers/android/baklava/images/factory/rango_beta-cp11.251114.007-factory-7c5f6c20.zip
 
+# 16 QPR3 Beta 2
+oriole CP11.251209.007:
+  factory: 09671c80eded857d0f30e258923b06afbdc22e68ebc17ca26d83dc3f5ba0e846 https://dl.google.com/developers/android/baklava/images/factory/oriole_beta-cp11.251209.007-factory-09671c80.zip
+  ota: 82bc8dd896787b7ff8d3282acf2da40b0ddf9fb4a0fd21a29f0dfec2c05d4600 https://dl.google.com/developers/android/baklava/images/ota/oriole_beta-ota-cp11.251209.007-82bc8dd8.zip
+raven CP11.251209.007:
+  factory: 5ea26bd7a00eb940209ee02a7575f7e21c22e85471fe720a6eaa3e68db3577b6 https://dl.google.com/developers/android/baklava/images/factory/raven_beta-cp11.251209.007-factory-5ea26bd7.zip
+  ota: dbc4c3c1c331930759cccedc1f2dfb8ee33d443ba8567fee0de6771c78e63614 https://dl.google.com/developers/android/baklava/images/ota/raven_beta-ota-cp11.251209.007-dbc4c3c1.zip
+bluejay CP11.251209.007:
+  factory: 9dd53248594203b55cb987fc65aff243fc416bcfa8777a199bd637e16dd3908a https://dl.google.com/developers/android/baklava/images/factory/bluejay_beta-cp11.251209.007-factory-9dd53248.zip
+panther CP11.251209.007:
+  factory: 4a5baba6cd43e40e601f469cd75bb3ae5f1c7071828582d7d3a9add97b688225 https://dl.google.com/developers/android/baklava/images/factory/panther_beta-cp11.251209.007-factory-4a5baba6.zip
+  ota: 63e0ccf5a167cca5ea938e4b5de8aa4c5b50755c649675aeffdab22db2bb17be https://dl.google.com/developers/android/baklava/images/ota/panther_beta-ota-cp11.251209.007-63e0ccf5.zip
+cheetah CP11.251209.007:
+  factory: f21e68f8f16940a339aaf4319938d956fa0ca2ac26d015849e3d27b4a937febf https://dl.google.com/developers/android/baklava/images/factory/cheetah_beta-cp11.251209.007-factory-f21e68f8.zip
+  ota: 46dd11d86d6ce6d7eb3027a5ec74821e872345d2e7e0a3621965aec558768a2a https://dl.google.com/developers/android/baklava/images/ota/cheetah_beta-ota-cp11.251209.007-46dd11d8.zip
+lynx CP11.251209.007.A1:
+  factory: 486edbce920d62b260496229f8c26c12e7a6071db3d5b8d411d95a151574a32f https://dl.google.com/developers/android/baklava/images/factory/lynx_beta-cp11.251209.007.a1-factory-486edbce.zip
+  ota: 4d34bdc3370cd9a59affceee30b2fbb18e0fb58052f6f8878740fcb756eda3a4 https://dl.google.com/developers/android/baklava/images/ota/lynx_beta-ota-cp11.251209.007.a1-4d34bdc3.zip
+felix CP11.251209.007.A1:
+  factory: e3a89184bcb161c9a2ff316fb78323e64c20b1653279ae7351d48a9b79aa6b66 https://dl.google.com/developers/android/baklava/images/factory/felix_beta-cp11.251209.007.a1-factory-e3a89184.zip
+  ota: 99ea2442b77b238f7ee45133e971df97282f731e61461f2105f56d839205b96a https://dl.google.com/developers/android/baklava/images/ota/felix_beta-ota-cp11.251209.007.a1-99ea2442.zip
+tangorpro CP11.251209.007.A1:
+  factory: 3be2a8626d3749ffdcceeaddb806fca5d3b4c6dfe1c6bab0fcda7ff288eb5119 https://dl.google.com/developers/android/baklava/images/factory/tangorpro_beta-cp11.251209.007.a1-factory-3be2a862.zip
+  ota: ff8f01159cd4191a39cf26a67a794c8a633936d70d39e469a8c67812168a84d5 https://dl.google.com/developers/android/baklava/images/ota/tangorpro_beta-ota-cp11.251209.007.a1-ff8f0115.zip
+shiba CP11.251209.007.A1:
+  factory: 50234f097028dcbb9868ba83c8a4b3174c18a1c593bd94827bace5b1637042b1 https://dl.google.com/developers/android/baklava/images/factory/shiba_beta-cp11.251209.007.a1-factory-50234f09.zip
+  ota: a3ed85e3350c7c5bb9d5caa9f66279cd837659f7043294e0f5b9b84bc73f707f https://dl.google.com/developers/android/baklava/images/ota/shiba_beta-ota-cp11.251209.007.a1-a3ed85e3.zip
+husky CP11.251209.007.A1:
+  factory: 111d0977eecf844be3f42372e52b16738c48e571fe8a6d5e89d6b8daf9d40e1b https://dl.google.com/developers/android/baklava/images/factory/husky_beta-cp11.251209.007.a1-factory-111d0977.zip
+  ota: a18d772acdc415bf5c2d25856af51efa34fda1c1c269380aea4858fbee62cff9 https://dl.google.com/developers/android/baklava/images/ota/husky_beta-ota-cp11.251209.007.a1-a18d772a.zip
+akita CP11.251209.007.A1:
+  factory: 2965a47a9ae7341689e000092d88145087927e93898bec06a2bac68322027a89 https://dl.google.com/developers/android/baklava/images/factory/akita_beta-cp11.251209.007.a1-factory-2965a47a.zip
+  ota: fda2f2366192a03f5bc6ef00c6c535ec0b6b981e14010a909d7a10067372eecb https://dl.google.com/developers/android/baklava/images/ota/akita_beta-ota-cp11.251209.007.a1-fda2f236.zip
+tokay CP11.251209.007.A1:
+  factory: 3bc4ab63de36320a856622675bd2f2b49a6c0ed06b32013f98d62fb8964a70f8 https://dl.google.com/developers/android/baklava/images/factory/tokay_beta-cp11.251209.007.a1-factory-3bc4ab63.zip
+  ota: e6a13078571e092e1c6dea302bf7399be5ba3978030e211f3f1317557bbfb805 https://dl.google.com/developers/android/baklava/images/ota/tokay_beta-ota-cp11.251209.007.a1-e6a13078.zip
+caiman CP11.251209.007.A1:
+  factory: bc3200b446e0cdea323e58c3539a226cbfdd100d15e549d0633e14935ce3f434 https://dl.google.com/developers/android/baklava/images/factory/caiman_beta-cp11.251209.007.a1-factory-bc3200b4.zip
+  ota: de2d4d9aab76b5ea5fb642e44eb135647cfadde13e36226995c4ff20a553463b https://dl.google.com/developers/android/baklava/images/ota/caiman_beta-ota-cp11.251209.007.a1-de2d4d9a.zip
+komodo CP11.251209.007.A1:
+  factory: afa77179f57403dee5c7842f9682e81908a1fd51285a3e19f70645317b724b7c https://dl.google.com/developers/android/baklava/images/factory/komodo_beta-cp11.251209.007.a1-factory-afa77179.zip
+  ota: 86818582c68a78a2db73d3516db6a40347025aa483ba6a843efb35ea03e10f4c https://dl.google.com/developers/android/baklava/images/ota/komodo_beta-ota-cp11.251209.007.a1-86818582.zip
+comet CP11.251209.007.A1:
+  factory: b723454db8f6ba655ef60c4fcac7ce60d8073896f91f942d1718dfa63ed5a478 https://dl.google.com/developers/android/baklava/images/factory/comet_beta-cp11.251209.007.a1-factory-b723454d.zip
+  ota: d33fb5e938e901277551ce9a106a6fa8bbd710c721bee113d73f7d29d580d253 https://dl.google.com/developers/android/baklava/images/ota/comet_beta-ota-cp11.251209.007.a1-d33fb5e9.zip
+tegu CP11.251209.007.A1:
+  factory: cf527fff94306f512e7d7b1469ca8820217f6cb7bba0d47b1d2a97f2fbd99733 https://dl.google.com/developers/android/baklava/images/factory/tegu_beta-cp11.251209.007.a1-factory-cf527fff.zip
+  ota: a8e5d842f3f4b630b765ea1e9f1ad266731ff4e126f80971131821afbc709dad https://dl.google.com/developers/android/baklava/images/ota/tegu_beta-ota-cp11.251209.007.a1-a8e5d842.zip
+frankel CP11.251209.007.A1:
+  factory: 9d9df97197e9988cb6fcd91290c6eee4de4f7831d4cc3deaa330a160a64ace71 https://dl.google.com/developers/android/baklava/images/factory/frankel_beta-cp11.251209.007.a1-factory-9d9df971.zip
+blazer CP11.251209.007.A1:
+  factory: 13cc2e28aea8f6d45cc7649f8708617328c0d222ba65fc3f2e6b83c77fab868a https://dl.google.com/developers/android/baklava/images/factory/blazer_beta-cp11.251209.007.a1-factory-13cc2e28.zip
+mustang CP11.251209.007.A1:
+  factory: 4de9209f9887c0a3aaff8de6e9ed94966e73c7c7d143679d6dd8888128dbd9a5 https://dl.google.com/developers/android/baklava/images/factory/mustang_beta-cp11.251209.007.a1-factory-4de9209f.zip
+rango CP11.251209.007.A1:
+  factory: 2608cf2362dc03302a7c9fa38f6f66ad9de6ba79f20c9931430ba7171ec38b34 https://dl.google.com/developers/android/baklava/images/factory/rango_beta-cp11.251209.007.a1-factory-2608cf23.zip
+

--- a/config/build-index/build-index-canary.yml
+++ b/config/build-index/build-index-canary.yml
@@ -1,3 +1,43 @@
+oriole ZP11.251212.007:
+  factory: e4a6b6184d599462671534de088ecb0c85e53a6c25e738fdaa9a7270d1c03452 https://dl.google.com/developers/android/CANARY/images/factory/oriole_beta-zp11.251212.007-factory-e4a6b618.zip
+raven ZP11.251212.007:
+  factory: 4ce215761bb702279e68f681c0b93112cd1bfceef93e76f27a779d1eb5280a64 https://dl.google.com/developers/android/CANARY/images/factory/raven_beta-zp11.251212.007-factory-4ce21576.zip
+bluejay ZP11.251212.007:
+  factory: 1b46d77e19d1350ffbe344537d9bc57b03173c3d5c626c20a3500bc673975a84 https://dl.google.com/developers/android/CANARY/images/factory/bluejay_beta-zp11.251212.007-factory-1b46d77e.zip
+panther ZP11.251212.007:
+  factory: ab4fdfc931c5bd619988f7117070f54f3c9e77ace2f6f96c155856915d611771 https://dl.google.com/developers/android/CANARY/images/factory/panther_beta-zp11.251212.007-factory-ab4fdfc9.zip
+cheetah ZP11.251212.007:
+  factory: 6788e40908bda0d25b5ea62521d89fd5c2e1bf365c641849e28fd8f02e2e47a0 https://dl.google.com/developers/android/CANARY/images/factory/cheetah_beta-zp11.251212.007-factory-6788e409.zip
+lynx ZP11.251212.007:
+  factory: 91878b4962801b7b9f3ab675dbbef75bc88654f572aaf2f02bd2e7775bb8ad8f https://dl.google.com/developers/android/CANARY/images/factory/lynx_beta-zp11.251212.007-factory-91878b49.zip
+felix ZP11.251212.007:
+  factory: 1d5f65d859ea88416ba44f32c38b9bd5202f5d47292df73b5f1997bd9bcd5068 https://dl.google.com/developers/android/CANARY/images/factory/felix_beta-zp11.251212.007-factory-1d5f65d8.zip
+tangorpro ZP11.251212.007:
+  factory: 5a1645552ab102463f2f172324f10451553bc4af7a3410f872735c5e17621bc1 https://dl.google.com/developers/android/CANARY/images/factory/tangorpro_beta-zp11.251212.007-factory-5a164555.zip
+shiba ZP11.251212.007:
+  factory: ba7c734057bc790686df9cf9f82be18271c9323967311261a9b6b07de07c8cb5 https://dl.google.com/developers/android/CANARY/images/factory/shiba_beta-zp11.251212.007-factory-ba7c7340.zip
+husky ZP11.251212.007:
+  factory: bf02c3cb77883322e61112fbf134027160b52444878f37f860675f308001c294 https://dl.google.com/developers/android/CANARY/images/factory/husky_beta-zp11.251212.007-factory-bf02c3cb.zip
+akita ZP11.251212.007:
+  factory: c901125d12cdc38ad2b39b619e3b28d14d9b653654e715617914a2dba17641ce https://dl.google.com/developers/android/CANARY/images/factory/akita_beta-zp11.251212.007-factory-c901125d.zip
+tokay ZP11.251212.007:
+  factory: d863fdb2967982cccaa6cc9a0a94816b54f0254cee46b1fe682670add282a9e2 https://dl.google.com/developers/android/CANARY/images/factory/tokay_beta-zp11.251212.007-factory-d863fdb2.zip
+caiman ZP11.251212.007:
+  factory: 7525ccd27ea56a24a7543d971daa8242bb589b70f412490dbada8432a67d1643 https://dl.google.com/developers/android/CANARY/images/factory/caiman_beta-zp11.251212.007-factory-7525ccd2.zip
+komodo ZP11.251212.007:
+  factory: 613d4c3a07998014390e3d4bb8e9329fbc5c9786e9c861f98310ae3b09dcb6af https://dl.google.com/developers/android/CANARY/images/factory/komodo_beta-zp11.251212.007-factory-613d4c3a.zip
+comet ZP11.251212.007:
+  factory: 5f97f4199117afb9469ccde9247b7f5dfa73cf317dea9577e6862d92b57057ca https://dl.google.com/developers/android/CANARY/images/factory/comet_beta-zp11.251212.007-factory-5f97f419.zip
+tegu ZP11.251212.007:
+  factory: 9d57f189f8094a5c21d85f3bfc3f5104de82f69c5b3a471b6d87c001bf5ac42b https://dl.google.com/developers/android/CANARY/images/factory/tegu_beta-zp11.251212.007-factory-9d57f189.zip
+frankel ZP11.251212.007:
+  factory: fb0c92438cf76ca8c33ec3edd0ba86f3173cfdecbf4e13ff00e489f82f7b4fa1 https://dl.google.com/developers/android/CANARY/images/factory/frankel_beta-zp11.251212.007-factory-fb0c9243.zip
+blazer ZP11.251212.007:
+  factory: cdced38282ce19665dcd6d1fc00818ba6ec735113031bd37e24c0b4072a5ac49 https://dl.google.com/developers/android/CANARY/images/factory/blazer_beta-zp11.251212.007-factory-cdced382.zip
+mustang ZP11.251212.007:
+  factory: 290faa035a43a1f82b6a5377fc8d12f18d6a899900c4935d7fd3c214c8870fda https://dl.google.com/developers/android/CANARY/images/factory/mustang_beta-zp11.251212.007-factory-290faa03.zip
+rango ZP11.251212.007:
+  factory: 42bf5401d27fc46a4e29d0ef8518758866e585d76cb4478cc7bfb2be3ad43448 https://dl.google.com/developers/android/CANARY/images/factory/rango_beta-zp11.251212.007-factory-42bf5401.zip
 oriole ZP11.251121.010:
   factory: 77d0e1417bcf66cb2f58db9e4963f680c8f9c2b67fefb7d0488d4af0b31e6579 https://dl.google.com/developers/android/CANARY/images/factory/oriole_beta-zp11.251121.010-factory-77d0e141.zip
 raven ZP11.251121.010:

--- a/src/blobs/copy.ts
+++ b/src/blobs/copy.ts
@@ -183,13 +183,18 @@ function patchGpsXml(orig: string) {
 }
 
 function patchGpsCfg(orig: string) {
-  return replaceLines(orig, line => {
-    if (line.startsWith('SUPL_SSL_METHOD=')) {
-      return 'SUPL_SSL_METHOD=TLSv1_3'
-    } else {
-      return line
-    }
-  })
+  let extraLines = ['UseNtpForAiding=0']
+  return (
+    extraLines.join('\n') +
+    '\n\n' +
+    replaceLines(orig, line => {
+      if (line.startsWith('SUPL_SSL_METHOD=')) {
+        return 'SUPL_SSL_METHOD=TLSv1_3'
+      } else {
+        return line
+      }
+    })
+  )
 }
 
 function replaceLines(multiLine: string, callbackFn: (value: string) => string) {

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -104,6 +104,11 @@ function clearStatusLines() {
 }
 
 function writeStatus(status: string) {
+  if (process.stdout.getWindowSize === undefined) {
+    origStdoutWrite(status + '\n')
+    return
+  }
+
   let width = process.stdout.getWindowSize()[0]
   let numLines = 0
   let lines = status.split('\n').filter(l => l.length > 0)

--- a/vendor-skels/google_devices/akita/proprietary/vendor/etc/gnss/gps.cfg
+++ b/vendor-skels/google_devices/akita/proprietary/vendor/etc/gnss/gps.cfg
@@ -1,3 +1,5 @@
+UseNtpForAiding=0
+
 GlueLayer_ToolConfigSelection=3
 debug_console=0
 debug_enable=0

--- a/vendor-skels/google_devices/blazer/proprietary/vendor/etc/gnss/gps.cfg
+++ b/vendor-skels/google_devices/blazer/proprietary/vendor/etc/gnss/gps.cfg
@@ -1,3 +1,5 @@
+UseNtpForAiding=0
+
 GlueLayer_ToolConfigSelection=3
 debug_console=0
 debug_enable=0

--- a/vendor-skels/google_devices/caiman/proprietary/vendor/etc/gnss/gps.cfg
+++ b/vendor-skels/google_devices/caiman/proprietary/vendor/etc/gnss/gps.cfg
@@ -1,3 +1,5 @@
+UseNtpForAiding=0
+
 GlueLayer_ToolConfigSelection=3
 debug_console=0
 debug_enable=0

--- a/vendor-skels/google_devices/comet/proprietary/vendor/etc/gnss/gps.cfg
+++ b/vendor-skels/google_devices/comet/proprietary/vendor/etc/gnss/gps.cfg
@@ -1,3 +1,5 @@
+UseNtpForAiding=0
+
 GlueLayer_ToolConfigSelection=3
 debug_console=0
 debug_enable=0

--- a/vendor-skels/google_devices/frankel/proprietary/vendor/etc/gnss/gps.cfg
+++ b/vendor-skels/google_devices/frankel/proprietary/vendor/etc/gnss/gps.cfg
@@ -1,3 +1,5 @@
+UseNtpForAiding=0
+
 GlueLayer_ToolConfigSelection=3
 debug_console=0
 debug_enable=0

--- a/vendor-skels/google_devices/komodo/proprietary/vendor/etc/gnss/gps.cfg
+++ b/vendor-skels/google_devices/komodo/proprietary/vendor/etc/gnss/gps.cfg
@@ -1,3 +1,5 @@
+UseNtpForAiding=0
+
 GlueLayer_ToolConfigSelection=3
 debug_console=0
 debug_enable=0

--- a/vendor-skels/google_devices/mustang/proprietary/vendor/etc/gnss/gps.cfg
+++ b/vendor-skels/google_devices/mustang/proprietary/vendor/etc/gnss/gps.cfg
@@ -1,3 +1,5 @@
+UseNtpForAiding=0
+
 GlueLayer_ToolConfigSelection=3
 debug_console=0
 debug_enable=0

--- a/vendor-skels/google_devices/rango/proprietary/vendor/etc/gnss/gps.cfg
+++ b/vendor-skels/google_devices/rango/proprietary/vendor/etc/gnss/gps.cfg
@@ -1,3 +1,5 @@
+UseNtpForAiding=0
+
 GlueLayer_ToolConfigSelection=3
 debug_console=0
 debug_enable=0

--- a/vendor-skels/google_devices/tegu/proprietary/vendor/etc/gnss/gps.cfg
+++ b/vendor-skels/google_devices/tegu/proprietary/vendor/etc/gnss/gps.cfg
@@ -1,3 +1,5 @@
+UseNtpForAiding=0
+
 GlueLayer_ToolConfigSelection=3
 debug_console=0
 debug_enable=0

--- a/vendor-skels/google_devices/tokay/proprietary/vendor/etc/gnss/gps.cfg
+++ b/vendor-skels/google_devices/tokay/proprietary/vendor/etc/gnss/gps.cfg
@@ -1,3 +1,5 @@
+UseNtpForAiding=0
+
 GlueLayer_ToolConfigSelection=3
 debug_console=0
 debug_enable=0

--- a/vendor-specs/google_devices/akita.yml
+++ b/vendor-specs/google_devices/akita.yml
@@ -3278,7 +3278,7 @@ proprietary/vendor/etc/fstab.zuma: ca1e1e1246c1ff40c1d41554f75185f10ce739242a5e1
 proprietary/vendor/etc/fstab.zuma-fips: fb3e337ac05d7dfe36cff661e8d2a39c314e7e606a1a306bc265bec57c7b41a2
 proprietary/vendor/etc/gnss: dir
 proprietary/vendor/etc/gnss/ca.pem: 20ce188c6b9673e03dc504784562a0db953efa638a8e094394c7e25cbb20ea0f
-proprietary/vendor/etc/gnss/gps.cfg: 112b0eedde6cd150b195dd6a216a266e3f29ec8f7aa42dade2e49698728ad854
+proprietary/vendor/etc/gnss/gps.cfg: acc8b880da5f16a3ee4ac3688d7adf9a8b8080f8591b85c5d1f1e1080a469fd2
 proprietary/vendor/etc/init: dir
 proprietary/vendor/etc/init.common.cfg: f4104573e29026ac335f03703e24242a304bd74cbb99f5d5848c9968901444fb
 proprietary/vendor/etc/init/Exynos_C2.rc: e1a67aedbf8524273e9b755409da6e4f5660631b59d6e502e35e4a778cb15422

--- a/vendor-specs/google_devices/blazer.yml
+++ b/vendor-specs/google_devices/blazer.yml
@@ -3353,7 +3353,7 @@ proprietary/vendor/etc/future_vt_prediction_model.tflite: dddd58cff4177e193fb0ef
 proprietary/vendor/etc/ggauge.ini: 664662c09bdf5c0604b16a73b37b4e8ccb5da51be7d8042bf741108180688270
 proprietary/vendor/etc/gnss: dir
 proprietary/vendor/etc/gnss/ca.pem: 730fc9a6b512cf2782351b22f870f83cbf79bd51a1891f22edb3bb987a5f2422
-proprietary/vendor/etc/gnss/gps.cfg: f335baddeed5b23523770735e8b60d12e602c4155ebd69da46460153b95dea55
+proprietary/vendor/etc/gnss/gps.cfg: ca7620c26b72700794ac9bcca17393d06d13ac9023b5cb3a2115654838ae56a2
 proprietary/vendor/etc/gnss/hash.bin: 359c9946f3a61f71afb5d03bc592055d6ce4316ea719f7a955ecf44524538435
 proprietary/vendor/etc/init: dir
 proprietary/vendor/etc/init.common.cfg: f4104573e29026ac335f03703e24242a304bd74cbb99f5d5848c9968901444fb

--- a/vendor-specs/google_devices/caiman.yml
+++ b/vendor-specs/google_devices/caiman.yml
@@ -3517,7 +3517,7 @@ proprietary/vendor/etc/fstab.zumapro-fips: 1b136e68224b3d08cdb38a8bb40ac37c77b9a
 proprietary/vendor/etc/ggauge.ini: 664662c09bdf5c0604b16a73b37b4e8ccb5da51be7d8042bf741108180688270
 proprietary/vendor/etc/gnss: dir
 proprietary/vendor/etc/gnss/ca.pem: 730fc9a6b512cf2782351b22f870f83cbf79bd51a1891f22edb3bb987a5f2422
-proprietary/vendor/etc/gnss/gps.cfg: d230a133d1640652d2083919e8ab1922896f62a00015d3655ef832edabac82a0
+proprietary/vendor/etc/gnss/gps.cfg: 0cfc1e6bf3179fad883238c06dafe8b7271973bde747a9e41ce76698e8c7eef5
 proprietary/vendor/etc/gnss/hash.bin: 359c9946f3a61f71afb5d03bc592055d6ce4316ea719f7a955ecf44524538435
 proprietary/vendor/etc/init: dir
 proprietary/vendor/etc/init.common.cfg: f4104573e29026ac335f03703e24242a304bd74cbb99f5d5848c9968901444fb

--- a/vendor-specs/google_devices/comet.yml
+++ b/vendor-specs/google_devices/comet.yml
@@ -3657,7 +3657,7 @@ proprietary/vendor/etc/fstab.zumapro: 55b645866df5a056d784e50ce4293e0a95ab034b55
 proprietary/vendor/etc/fstab.zumapro-fips: 1b136e68224b3d08cdb38a8bb40ac37c77b9a601b57dab91119e7d6e7c668449
 proprietary/vendor/etc/gnss: dir
 proprietary/vendor/etc/gnss/ca.pem: 730fc9a6b512cf2782351b22f870f83cbf79bd51a1891f22edb3bb987a5f2422
-proprietary/vendor/etc/gnss/gps.cfg: ed25bc85dbd7f98089c41e81610d467c809dc640ca2ec01495a2f2ab73af0b89
+proprietary/vendor/etc/gnss/gps.cfg: fb5a24f22c598f98cc6ad1c4717812de95dcddf2a53c6327b015f44dd9b79ba0
 proprietary/vendor/etc/gnss/hash.bin: 359c9946f3a61f71afb5d03bc592055d6ce4316ea719f7a955ecf44524538435
 proprietary/vendor/etc/init: dir
 proprietary/vendor/etc/init.common.cfg: f4104573e29026ac335f03703e24242a304bd74cbb99f5d5848c9968901444fb

--- a/vendor-specs/google_devices/frankel.yml
+++ b/vendor-specs/google_devices/frankel.yml
@@ -3347,7 +3347,7 @@ proprietary/vendor/etc/future_vt_prediction_model.tflite: a15166f122081843a05ba0
 proprietary/vendor/etc/ggauge.ini: 664662c09bdf5c0604b16a73b37b4e8ccb5da51be7d8042bf741108180688270
 proprietary/vendor/etc/gnss: dir
 proprietary/vendor/etc/gnss/ca.pem: 730fc9a6b512cf2782351b22f870f83cbf79bd51a1891f22edb3bb987a5f2422
-proprietary/vendor/etc/gnss/gps.cfg: e5b7447a22e223fbfdbe6bd189468fc27412c56fe37d834df35cb1eb162cd8d4
+proprietary/vendor/etc/gnss/gps.cfg: 54fc011b8823d5bf5548cdc35ea96c0190d239dd54ed7f121df0a8c460d7dd12
 proprietary/vendor/etc/gnss/hash.bin: 359c9946f3a61f71afb5d03bc592055d6ce4316ea719f7a955ecf44524538435
 proprietary/vendor/etc/init: dir
 proprietary/vendor/etc/init.common.cfg: f4104573e29026ac335f03703e24242a304bd74cbb99f5d5848c9968901444fb

--- a/vendor-specs/google_devices/komodo.yml
+++ b/vendor-specs/google_devices/komodo.yml
@@ -3518,7 +3518,7 @@ proprietary/vendor/etc/fstab.zumapro-fips: 1b136e68224b3d08cdb38a8bb40ac37c77b9a
 proprietary/vendor/etc/ggauge.ini: 664662c09bdf5c0604b16a73b37b4e8ccb5da51be7d8042bf741108180688270
 proprietary/vendor/etc/gnss: dir
 proprietary/vendor/etc/gnss/ca.pem: 730fc9a6b512cf2782351b22f870f83cbf79bd51a1891f22edb3bb987a5f2422
-proprietary/vendor/etc/gnss/gps.cfg: 7097a3d6d8b46d5ed390595f465e6e7fff5a275cb6633d9687160309ac94a357
+proprietary/vendor/etc/gnss/gps.cfg: d8126daed8cef787dc591b7880fe21405464e19d9fcfa6f5833645b5eeada218
 proprietary/vendor/etc/gnss/hash.bin: 359c9946f3a61f71afb5d03bc592055d6ce4316ea719f7a955ecf44524538435
 proprietary/vendor/etc/init: dir
 proprietary/vendor/etc/init.common.cfg: f4104573e29026ac335f03703e24242a304bd74cbb99f5d5848c9968901444fb

--- a/vendor-specs/google_devices/mustang.yml
+++ b/vendor-specs/google_devices/mustang.yml
@@ -3355,7 +3355,7 @@ proprietary/vendor/etc/future_vt_prediction_model.tflite: 32650d93a72d808c638f77
 proprietary/vendor/etc/ggauge.ini: 664662c09bdf5c0604b16a73b37b4e8ccb5da51be7d8042bf741108180688270
 proprietary/vendor/etc/gnss: dir
 proprietary/vendor/etc/gnss/ca.pem: 730fc9a6b512cf2782351b22f870f83cbf79bd51a1891f22edb3bb987a5f2422
-proprietary/vendor/etc/gnss/gps.cfg: 97829ec5e11e6ad653293340812fb3c392d18d4d3cf216275a2cc3446d773a7e
+proprietary/vendor/etc/gnss/gps.cfg: ce62c586af1f35ce65339acc2d14bff77d1c0d766aab142c6fbb6dfd8eb2db43
 proprietary/vendor/etc/gnss/hash.bin: 359c9946f3a61f71afb5d03bc592055d6ce4316ea719f7a955ecf44524538435
 proprietary/vendor/etc/init: dir
 proprietary/vendor/etc/init.common.cfg: f4104573e29026ac335f03703e24242a304bd74cbb99f5d5848c9968901444fb

--- a/vendor-specs/google_devices/rango.yml
+++ b/vendor-specs/google_devices/rango.yml
@@ -3627,7 +3627,7 @@ proprietary/vendor/etc/fstab.zram.60p: c92876dab839b6fc020962b49efaf744bad8dc73c
 proprietary/vendor/etc/fstab.zram.6g: c95836903adda8686c47db76c8aca64c52a45c74a6628db3ab641b41805123ef
 proprietary/vendor/etc/gnss: dir
 proprietary/vendor/etc/gnss/ca.pem: 730fc9a6b512cf2782351b22f870f83cbf79bd51a1891f22edb3bb987a5f2422
-proprietary/vendor/etc/gnss/gps.cfg: 0e955e8937d0b2863d5bc1f6a651b7c67d22961f03fdfd77e2555907718802f5
+proprietary/vendor/etc/gnss/gps.cfg: 0e7609195ee8baf09c075bcfea9869b5953c84346de8d3a0a435d3d74f119cd9
 proprietary/vendor/etc/gnss/hash.bin: 359c9946f3a61f71afb5d03bc592055d6ce4316ea719f7a955ecf44524538435
 proprietary/vendor/etc/init: dir
 proprietary/vendor/etc/init.common.cfg: f4104573e29026ac335f03703e24242a304bd74cbb99f5d5848c9968901444fb

--- a/vendor-specs/google_devices/tegu.yml
+++ b/vendor-specs/google_devices/tegu.yml
@@ -3311,7 +3311,7 @@ proprietary/vendor/etc/fstab.zumapro: 55b645866df5a056d784e50ce4293e0a95ab034b55
 proprietary/vendor/etc/fstab.zumapro-fips: 1b136e68224b3d08cdb38a8bb40ac37c77b9a601b57dab91119e7d6e7c668449
 proprietary/vendor/etc/gnss: dir
 proprietary/vendor/etc/gnss/ca.pem: 20ce188c6b9673e03dc504784562a0db953efa638a8e094394c7e25cbb20ea0f
-proprietary/vendor/etc/gnss/gps.cfg: 62a27e24c5db015468ccf847b641d7685c639c4ff66480dc2311cd2c055ea380
+proprietary/vendor/etc/gnss/gps.cfg: 50ff9dfec55b8f024574ed3eaf024d5e74109bd4d0ffeddecadd1c059e784eb2
 proprietary/vendor/etc/init: dir
 proprietary/vendor/etc/init.common.cfg: f4104573e29026ac335f03703e24242a304bd74cbb99f5d5848c9968901444fb
 proprietary/vendor/etc/init/Exynos_C2.rc: e1a67aedbf8524273e9b755409da6e4f5660631b59d6e502e35e4a778cb15422

--- a/vendor-specs/google_devices/tokay.yml
+++ b/vendor-specs/google_devices/tokay.yml
@@ -3504,7 +3504,7 @@ proprietary/vendor/etc/fstab.zumapro-fips: 1b136e68224b3d08cdb38a8bb40ac37c77b9a
 proprietary/vendor/etc/ggauge.ini: 664662c09bdf5c0604b16a73b37b4e8ccb5da51be7d8042bf741108180688270
 proprietary/vendor/etc/gnss: dir
 proprietary/vendor/etc/gnss/ca.pem: 730fc9a6b512cf2782351b22f870f83cbf79bd51a1891f22edb3bb987a5f2422
-proprietary/vendor/etc/gnss/gps.cfg: a662c5f8a15d88defdcf9de1be271133ef1309132b7b50ea173fb943fd757b91
+proprietary/vendor/etc/gnss/gps.cfg: 58a332c18d7f060d8f1962638766ab2f7ff5a6edd1677cdc0cbddd29d7261aa8
 proprietary/vendor/etc/gnss/hash.bin: 359c9946f3a61f71afb5d03bc592055d6ce4316ea719f7a955ecf44524538435
 proprietary/vendor/etc/init: dir
 proprietary/vendor/etc/init.common.cfg: f4104573e29026ac335f03703e24242a304bd74cbb99f5d5848c9968901444fb


### PR DESCRIPTION
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/5791
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/6581