### PR TITLE
use dual arch Vanadium for 6th gen

### DIFF
--- a/config/device/common/gen6pixel.yml
+++ b/config/device/common/gen6pixel.yml
@@ -136,6 +136,9 @@ filters:
       - vendor/lib/vendor.samsung_slsi.telephony.hardware.radioExternal@1.1.so
       - vendor_ramdisk/lib/firmware/drv2624.bin
 
+replacement_module_exclusions:
+  - TrichromeLibrary # external/vanadium | product/app/TrichromeLibrary/TrichromeLibrary.apk
+
 replacement_module_inclusions:
   - android.frameworks.stats-V1-cpp.vendor:64 # frameworks/hardware/interfaces/stats/aidl | vendor/lib64/android.frameworks.stats-V1-cpp.so
   - android.frameworks.stats-V1-ndk.vendor:64 # frameworks/hardware/interfaces/stats/aidl | vendor/lib64/android.frameworks.stats-V1-ndk.so
@@ -268,3 +271,8 @@ replacement_module_inclusions:
   - libui.vendor:64 # frameworks/native/libs/ui | vendor/lib64/libui.so
   - libunwindstack.vendor:64 # system/unwinding/libunwindstack | vendor/lib64/libunwindstack.so
   - nfc_nci.st21nfc.default:64 # hardware/st/nfc/st21nfc | vendor/lib64/nfc_nci.st21nfc.default.so
+
+unique_base_apks:
+  - product/app/TrichromeChromeDualArch/TrichromeChromeDualArch.apk
+  - product/app/TrichromeLibraryDualArch/TrichromeLibraryDualArch.apk
+  - product/app/TrichromeWebViewDualArch/TrichromeWebViewDualArch.apk

--- a/config/mk/google_devices/platform/gs101/product-common.mk
+++ b/config/mk/google_devices/platform/gs101/product-common.mk
@@ -16,6 +16,10 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/telephony_system_ext.mk)
 #
 $(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_product.mk)
 
+PRODUCT_PACKAGES += \
+    TrichromeWebViewDualArch \
+    TrichromeChromeDualArch
+
 #
 # All components inherited here go to vendor image
 #

--- a/vendor-skels/google_devices/bluejay/bluejay.mk
+++ b/vendor-skels/google_devices/bluejay/bluejay.mk
@@ -1361,7 +1361,6 @@ PRODUCT_COPY_FILES += \
     vendor/google_devices/bluejay/proprietary/system_ext/priv-app/EuiccSupportPixel/DKA_RC7_EVT.up:$(TARGET_COPY_OUT_SYSTEM_EXT)/priv-app/EuiccSupportPixel/DKA_RC7_EVT.up \
     vendor/google_devices/bluejay/proprietary/system_ext/priv-app/EuiccSupportPixel/esim-full-v1-security.img:$(TARGET_COPY_OUT_SYSTEM_EXT)/priv-app/EuiccSupportPixel/esim-full-v1-security.img \
     vendor/google_devices/bluejay/proprietary/system_ext/priv-app/EuiccSupportPixel/esim-full-v1.img:$(TARGET_COPY_OUT_SYSTEM_EXT)/priv-app/EuiccSupportPixel/esim-full-v1.img \
-    vendor/google_devices/bluejay/proprietary/vendor_dlkm/etc/init.insmod.bluejay.cfg:$(TARGET_COPY_OUT_VENDOR_DLKM)/etc/init.insmod.bluejay.cfg \
     vendor/google_devices/bluejay/proprietary/vendor_ramdisk/lib/firmware/drv2624.bin:$(TARGET_COPY_OUT_VENDOR_RAMDISK)/first_stage_ramdisk/lib/firmware/drv2624.bin \
     vendor/google_devices/bluejay/proprietary/vendor_ramdisk/system/etc/fstab.gs101:$(TARGET_COPY_OUT_VENDOR_RAMDISK)/first_stage_ramdisk/system/etc/fstab.gs101 \
     vendor/google_devices/bluejay/proprietary/vendor_ramdisk/system/etc/fstab.gs101-fips:$(TARGET_COPY_OUT_VENDOR_RAMDISK)/first_stage_ramdisk/system/etc/fstab.gs101-fips \

--- a/vendor-skels/google_devices/oriole/oriole.mk
+++ b/vendor-skels/google_devices/oriole/oriole.mk
@@ -1384,7 +1384,6 @@ PRODUCT_COPY_FILES += \
     vendor/google_devices/oriole/proprietary/system_ext/priv-app/EuiccSupportPixel/esim-full-v0-security.img:$(TARGET_COPY_OUT_SYSTEM_EXT)/priv-app/EuiccSupportPixel/esim-full-v0-security.img \
     vendor/google_devices/oriole/proprietary/system_ext/priv-app/EuiccSupportPixel/esim-full-v0.img:$(TARGET_COPY_OUT_SYSTEM_EXT)/priv-app/EuiccSupportPixel/esim-full-v0.img \
     vendor/google_devices/oriole/proprietary/system_ext/priv-app/EuiccSupportPixel/esim-full-v1.img:$(TARGET_COPY_OUT_SYSTEM_EXT)/priv-app/EuiccSupportPixel/esim-full-v1.img \
-    vendor/google_devices/oriole/proprietary/vendor_dlkm/etc/init.insmod.oriole.cfg:$(TARGET_COPY_OUT_VENDOR_DLKM)/etc/init.insmod.oriole.cfg \
     vendor/google_devices/oriole/proprietary/vendor_ramdisk/lib/firmware/drv2624.bin:$(TARGET_COPY_OUT_VENDOR_RAMDISK)/first_stage_ramdisk/lib/firmware/drv2624.bin \
     vendor/google_devices/oriole/proprietary/vendor_ramdisk/system/etc/fstab.gs101:$(TARGET_COPY_OUT_VENDOR_RAMDISK)/first_stage_ramdisk/system/etc/fstab.gs101 \
     vendor/google_devices/oriole/proprietary/vendor_ramdisk/system/etc/fstab.gs101-fips:$(TARGET_COPY_OUT_VENDOR_RAMDISK)/first_stage_ramdisk/system/etc/fstab.gs101-fips \

--- a/vendor-skels/google_devices/raven/raven.mk
+++ b/vendor-skels/google_devices/raven/raven.mk
@@ -1390,7 +1390,6 @@ PRODUCT_COPY_FILES += \
     vendor/google_devices/raven/proprietary/system_ext/priv-app/EuiccSupportPixel/esim-full-v0-security.img:$(TARGET_COPY_OUT_SYSTEM_EXT)/priv-app/EuiccSupportPixel/esim-full-v0-security.img \
     vendor/google_devices/raven/proprietary/system_ext/priv-app/EuiccSupportPixel/esim-full-v0.img:$(TARGET_COPY_OUT_SYSTEM_EXT)/priv-app/EuiccSupportPixel/esim-full-v0.img \
     vendor/google_devices/raven/proprietary/system_ext/priv-app/EuiccSupportPixel/esim-full-v1.img:$(TARGET_COPY_OUT_SYSTEM_EXT)/priv-app/EuiccSupportPixel/esim-full-v1.img \
-    vendor/google_devices/raven/proprietary/vendor_dlkm/etc/init.insmod.raven.cfg:$(TARGET_COPY_OUT_VENDOR_DLKM)/etc/init.insmod.raven.cfg \
     vendor/google_devices/raven/proprietary/vendor_ramdisk/lib/firmware/drv2624.bin:$(TARGET_COPY_OUT_VENDOR_RAMDISK)/first_stage_ramdisk/lib/firmware/drv2624.bin \
     vendor/google_devices/raven/proprietary/vendor_ramdisk/system/etc/fstab.gs101:$(TARGET_COPY_OUT_VENDOR_RAMDISK)/first_stage_ramdisk/system/etc/fstab.gs101 \
     vendor/google_devices/raven/proprietary/vendor_ramdisk/system/etc/fstab.gs101-fips:$(TARGET_COPY_OUT_VENDOR_RAMDISK)/first_stage_ramdisk/system/etc/fstab.gs101-fips \

--- a/vendor-specs/google_devices/bluejay.yml
+++ b/vendor-specs/google_devices/bluejay.yml
@@ -5,7 +5,7 @@ README.md: 982cac6e61cdbf5cd9c3dc0fdc543d18a7c70cc153e5a79ec5c7031ab6687f07
 apk-parser-config: dir
 apk-parser-config/Android.bp: 6d6401321d50122166ac7cd71142453a4e2e217812b514b04b8e958d24532585
 apk-parser-config/apk-parser-config.pb: 1336bfbf615e07d5c5df2d544748acbffe7435e958f4dfb384ae4304f6cf1de3
-bluejay.mk: 690353ee6a9376a51bc5046bcf870595d2cbf7ed533abc9f71407a2411c33e39
+bluejay.mk: f956b3f8f6821f5e9d42147e42daf7ce38728745312d63313376696047ef6e16
 cmds-for-envsetup.sh: 56fa26e2f60b5443f006b106242af91d221d91fc7f544979ed4f3ba00008c7b5
 firmware: dir
 firmware/abl.img: c26ac0fff157a537ad00f00b612cb91cd9c9b18600d9fcc1ad02f4a6438cd304
@@ -4750,9 +4750,6 @@ proprietary/vendor/lib64/vendor.samsung_slsi.telephony.hardware.radioExternal@1.
 proprietary/vendor/lib64/vendor.samsung_slsi.telephony.hardware.radioExternal@1.1.so: 8084cfa0cffee567dbc0d1bb63fdbf2e9ab9ff2d626f8c1d595e89a99bb11544
 proprietary/vendor/lib64/vendor_chre_atoms_log.so: aba309cfc53787c1b7dcd36be3c22f1d42dc080da6e30e0dc7a3b0f912d25de6
 proprietary/vendor/lib64/vendor_chre_metrics-cpp.so: d549d33ba723c03880b1b1d36128a24eab0a3145864595650517890548549ca3
-proprietary/vendor_dlkm: dir
-proprietary/vendor_dlkm/etc: dir
-proprietary/vendor_dlkm/etc/init.insmod.bluejay.cfg: d72353272c74d87540155a9e09c89a6c86a16578c90b37870b00b7f041b48ad7
 proprietary/vendor_ramdisk: dir
 proprietary/vendor_ramdisk/lib: dir
 proprietary/vendor_ramdisk/lib/firmware: dir

--- a/vendor-specs/google_devices/oriole.yml
+++ b/vendor-specs/google_devices/oriole.yml
@@ -19,7 +19,7 @@ firmware/modem.img: 87e221885a76b5e2139ac245013e81e6d95762cae301d0628d4ba4928512
 firmware/pbl.img: ff30197652be20c20376f8a69355edb09b123e19090654000ea7686ff0f8bc6d
 firmware/radio.img: 9f4a6e04c9aea0d334e789830026012757ba103732c968a921e4e5037786a4ac
 firmware/tzsw.img: 72ec9397796e4e59ba3cc158a1833a9f425bbf0d232800117df45fcc217fb829
-oriole.mk: 2e13b86a0aa6ac8c0d8a0c4782b5841f89cbf52320aa7d6d1ea3b218c27fb326
+oriole.mk: 243455799cb6fd76158a1ab08538f5c575357dbcbc701a908feda7c62e6b795c
 overlays: dir
 overlays/Android.bp: c9ffd08891ecb53ae8e9094354e795dd69f8739b43792c4ad4b3bc7c768affcf
 overlays/CellBroadcastReceiverOverlay: dir
@@ -4757,9 +4757,6 @@ proprietary/vendor/lib64/vendor.samsung_slsi.telephony.hardware.radioExternal@1.
 proprietary/vendor/lib64/vendor.samsung_slsi.telephony.hardware.radioExternal@1.1.so: 8084cfa0cffee567dbc0d1bb63fdbf2e9ab9ff2d626f8c1d595e89a99bb11544
 proprietary/vendor/lib64/vendor_chre_atoms_log.so: aba309cfc53787c1b7dcd36be3c22f1d42dc080da6e30e0dc7a3b0f912d25de6
 proprietary/vendor/lib64/vendor_chre_metrics-cpp.so: d549d33ba723c03880b1b1d36128a24eab0a3145864595650517890548549ca3
-proprietary/vendor_dlkm: dir
-proprietary/vendor_dlkm/etc: dir
-proprietary/vendor_dlkm/etc/init.insmod.oriole.cfg: 37121a8571b8ee6ef7cf22dd743fee9c755376070d4794982adcdc2648e3faff
 proprietary/vendor_ramdisk: dir
 proprietary/vendor_ramdisk/lib: dir
 proprietary/vendor_ramdisk/lib/firmware: dir

--- a/vendor-specs/google_devices/raven.yml
+++ b/vendor-specs/google_devices/raven.yml
@@ -4981,9 +4981,6 @@ proprietary/vendor/lib64/vendor.samsung_slsi.telephony.hardware.radioExternal@1.
 proprietary/vendor/lib64/vendor.samsung_slsi.telephony.hardware.radioExternal@1.1.so: 8084cfa0cffee567dbc0d1bb63fdbf2e9ab9ff2d626f8c1d595e89a99bb11544
 proprietary/vendor/lib64/vendor_chre_atoms_log.so: aba309cfc53787c1b7dcd36be3c22f1d42dc080da6e30e0dc7a3b0f912d25de6
 proprietary/vendor/lib64/vendor_chre_metrics-cpp.so: d549d33ba723c03880b1b1d36128a24eab0a3145864595650517890548549ca3
-proprietary/vendor_dlkm: dir
-proprietary/vendor_dlkm/etc: dir
-proprietary/vendor_dlkm/etc/init.insmod.raven.cfg: 5ea610d6cef2614d77145cada77d38e1f1047590a55857819f1c0fa9842cfcc4
 proprietary/vendor_ramdisk: dir
 proprietary/vendor_ramdisk/lib: dir
 proprietary/vendor_ramdisk/lib/firmware: dir
@@ -4992,7 +4989,7 @@ proprietary/vendor_ramdisk/system: dir
 proprietary/vendor_ramdisk/system/etc: dir
 proprietary/vendor_ramdisk/system/etc/fstab.gs101: 06d94291a0bdaf437b54b861418b2c759e9ac1310de1bb44dddd9f6b7bc5e0f8
 proprietary/vendor_ramdisk/system/etc/fstab.gs101-fips: 06d94291a0bdaf437b54b861418b2c759e9ac1310de1bb44dddd9f6b7bc5e0f8
-raven.mk: c20848d27fe27fd17fd337d109791783667652dae34b09deeacf7cc3750cd700
+raven.mk: db3ced3b532cc197fb8a2ce0e2645988c1d48a7d1897b403c77065e0de7429fa
 sepolicy: dir
 sepolicy/product: dir
 sepolicy/product/private: dir


### PR DESCRIPTION
Requires external/vanadium change

7th gen and above will use 64-bit-only APKs. Including the dual arch APKs will override the 64-bit-only APKs.