### PR TITLE
add synthetic overlay for auto data switch enabling cross SIM calling

### DIFF
--- a/config/device/common/overlay-inclusion.yml
+++ b/config/device/common/overlay-inclusion.yml
@@ -722,6 +722,7 @@ filters:
       - com.android.settings:array/when_to_start_screensaver_values_no_battery|*
       - com.android.settings:bool/config_adaptive_alert_vibration_enabled = true
       - com.android.settings:bool/config_adaptive_touch_sensitivity_enabled = true
+      - com.android.settings:bool/config_auto_data_switch_enables_cross_sim_calling|*
       - com.android.settings:bool/config_battery_first_use_date_enabled = false
       - com.android.settings:bool/config_clear_calling_enabled = false
       - com.android.settings:bool/config_clear_calling_enabled = true

--- a/config/device/common/synthetic-overlays.yml
+++ b/config/device/common/synthetic-overlays.yml
@@ -5,6 +5,7 @@ synthetic_overlays:
     targetPackage: com.android.settings
     resourcesToInclude:
       bool:
+        - config_auto_data_switch_enables_cross_sim_calling
         - config_show_smooth_display
         - config_show_touch_sensitivity
       drawable:


### PR DESCRIPTION
As suggested by @inthewaves, reverted my previous attempt and and added this commit https://github.com/GrapheneOS/adevtool/pull/256/changes/34b56cc79667bc35ba3c19c9559e60bf4660e8a8.

It's working as expected on a set of four eSIM for me.