### PR TITLE
remove unintended short-circuit evaluation in processSepolicy()

### DIFF
--- a/src/processor/sepolicy.ts
+++ b/src/processor/sepolicy.ts
@@ -292,7 +292,9 @@ export async function processSepolicy(
           yamlPath: ['', part, 'mac_permissions_entries'],
         } as EntryFilterSpec,
       } as ProcessXmlCmd
-      writtenAny ||= (await processXml(cmd)).length > 0
+      if ((await processXml(cmd)).length > 0) {
+        writtenAny = true
+      }
     })()
 
     await Promise.all(contextsJobs.concat(...[macPermsJob, typesJob, sepolicyExtJob]))


### PR DESCRIPTION
This bug was timing-dependent and was reliably detected by vendor-specs file checksum checks.