### PR TITLE
backport Pixel camera HAL APEX from 16 QPR3

### DIFF
--- a/config/device/common/backport.yml
+++ b/config/device/common/backport.yml
@@ -27,6 +27,7 @@ backport_files:
     - priv-app/ShannonIms/ShannonIms.apk
     - priv-app/ShannonRcs/ShannonRcs.apk
   vendor:
+    - apex/com.google.pixel.camera.hal.apex
     - apex/com.google.pixel.euicc.update.apex
     - bin/hw/android.hardware.neuralnetworks@service-darwinn-aidl
     - bin/hw/android.hardware.thermal-service.pixel

--- a/vendor-specs/google_devices/akita.yml
+++ b/vendor-specs/google_devices/akita.yml
@@ -3084,7 +3084,7 @@ proprietary/system_ext/priv-app/ril-extension/ril-extension.apk: 73d8c1a975350b9
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 02566061d1d76a943b96707d5d156f292ecf81eefcc1219e400b167322aad9af
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: c2699e35c7e4ac7746330f216d0366c16f9afa98f9328fe82f3556ffacfefdfa
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: dcf1fd168538c24be49a848b082f080d7072af1846b5a4af1785176c50817351
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 6e3e8db76b1a4b00056f0d5cdef994a162fea7e4e6014d00d06fbbb198ff7528
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 24b9ee0d4014c43dc55af508158bf9ed787cd612f296a0bfd9f96cf2b3f4b3c4
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/blazer.yml
+++ b/vendor-specs/google_devices/blazer.yml
@@ -3090,7 +3090,7 @@ proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: f13599123a823838b1ed8cd99a1cc8ac0efcb901c561620fab1b95b4abaf2bee
 proprietary/vendor/apex/com.google.muzel.hardware.threadnetwork.apex: 2cae07e1949fec4ab49eb88243215e0c0893b3136cf537d28de130b4bdd6cd6a
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 30fb83c289df24e90b51401e5f4df8cacd765f32038c2970b6e8255f926d103f
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: b6713067dddddd6770b5880a9c65ceb91ab6d952c834cf4d0bf942ecd9730f44
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 8cc6480083f570ba66f33d087513ef47b07601c271150edbb00faeabb76777d2
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: d385e9f99b691683f411f9773556b36109f8cb9dd7b503c4d94cb22ca27ebb41
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/bluejay.yml
+++ b/vendor-specs/google_devices/bluejay.yml
@@ -3198,7 +3198,7 @@ proprietary/system_ext/priv-app/ShannonRcs/ShannonRcs.apk: 51e223c2cae76a1a7b29d
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 7ff8351ba9ac03424fbeca350fa3731bc5661618b287c1079a62df173d14fb0c
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 611c703c841be7dc30a0d8fce197814b6a7876a0533eee55c658d59a3e5b2f54
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 111a1ff5ace6f0b462cfeb9477d519b7ad3f88b66d4865af1359d93b8dac9f42
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 6a93171e2801ef3ef789d51d81068d060f4e4878951a2fc10a37d6743ee69513
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 299beb51aae3a48a456707e8282f83c71bfaae68d0b08a93576fd6c16e212585
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/caiman.yml
+++ b/vendor-specs/google_devices/caiman.yml
@@ -3291,7 +3291,7 @@ proprietary/system_ext/priv-app/ril-extension/ril-extension.apk: fe3077c2c2ab79d
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 353e7977dcc0a21d892ade61bf1eda313903b60e1e7efbe9e9ca92230e61447b
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 5c54c95529b445d431e105978a9cad4844e7c528ac463cb5805c4cf917ee0e2c
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: d6c3531e96d12d17efb7d8cf80087d0d24f0068404a00341d892823a5d2e1912
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 6545af6a283b765df9a3d7d0633fd840acedcd14e7c1a63aa6c602745b5c6bb4
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: e3ccc824b8a4de4be8b70c75576c59526557e20dd518e82de9f871f1df23a498
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/cheetah.yml
+++ b/vendor-specs/google_devices/cheetah.yml
@@ -3513,7 +3513,7 @@ proprietary/system_ext/priv-app/UwbVendorService/UwbVendorService.apk: 4921c4be0
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: b0e8b43e7ea2b97f753b6a38e4a28cf750d901aafb31b1ab7f0ef9b0df97dbe9
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 27747d0f3ddf4a950e4de612cc8da68485e0af6c0d5e82d2a50c46a1f7458258
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: b3e49a5879f699f4471b5bccc4020fc709429c07ef813dd9c6b1443990e873ef
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 63a515dc8e75e5db3658f523be935c33fb6f725d836c1805b0367d499039ec59
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: da2839580f8de4dd1a827f1c17e76d16e3f910e3106de51298d4152a46415373
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/comet.yml
+++ b/vendor-specs/google_devices/comet.yml
@@ -3422,7 +3422,7 @@ proprietary/system_ext/priv-app/ril-extension/ril-extension.apk: 7edca7725e77264
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 2bae42081e12855af6fb755b8889b98659a7ab14988ccf6823a1035bf634e24b
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 12f42c94174e3c7b80f0f6de06a453bf64e1359ec7592abffaa37912d2a95454
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 354456e8e9c08ae8c308dc83e51b6f5ac8e54cb6c016f98232f21353fcee9faf
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: fd8d502b770a6dde363de50bc10f69178798ce7f3e49cdb9ee3784f489f0cdd5
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: f8724a414667cc84886173c5b35b07560e2bfb3e29cf269a660ae51151987b50
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/felix.yml
+++ b/vendor-specs/google_devices/felix.yml
@@ -4173,7 +4173,7 @@ proprietary/system_ext/priv-app/UwbVendorService/UwbVendorService.apk: cff25df2b
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 74a82675fb43e1580e10abce1900bea9697e274c06b0be6d479265016ed7fce8
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 9a4070690b541c831498d9d02bcda801b739cca95b451d45276c11dadcbfc40e
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 49a0876d7135507d0f29026a2285a401c1ccd2aabf4b5454ababd12e5066360e
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: b517ec1867b70a151613af1abf8e1679be4bf157dcbe8e43f44700d9b5a3c94d
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 379bd005d2666acd16cd9034a40629438744c257092eef7e0edbe46b3ab8f863
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/frankel.yml
+++ b/vendor-specs/google_devices/frankel.yml
@@ -3072,7 +3072,7 @@ proprietary/system_ext/priv-app/ril-extension/ril-extension.apk: 87eec6f1f5a71b1
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 87373b43ea691085d7ca974d51fc1e8b4fc35b719281641e1c1420d077b9a71e
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 826ce610f6ab2cd2fb67350fb59b7e58f89c3b9787e374f1e8712a8b9a1b7c76
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: b67e4b9147f8cd6276db3dd0fbd5b6841ce6ce3e92f7161a4399769288a197e3
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 752455181ed4484e469119491498ed70806a74c5ca7f8be92f7bc33f87db5524
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 8babc4a7ccb2545e95d0a9eef34097acda3592f7a594fa49f49273631e840620
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/husky.yml
+++ b/vendor-specs/google_devices/husky.yml
@@ -3068,7 +3068,7 @@ proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.hardware.biometrics.fingerprint.apex: 9a65438772f0d0e0c20bea2500ae777f47189fe91cc77b7c5d6f774f1a2a63d1
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: fdabd9c5e6e5cd65de5c6da939117d10fffdfd2cc6998c44ff0220e41004adb0
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 9eca740b9fa0ae63be3c9fdb98a34a3c8e7c0557da173576bc3894d89658ac0a
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: d209c37c2bacf8df3d70db8a8456b1c73e8177a0acb98b57148252fb25ed2714
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 10a02cf3c23acd0b696ecc3d4b491a862fa9a998b67df257945bd973eb883ebc
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 72ef825737d16cf6a342e5e841b2d60a8d8c398686e2bdc10813434f0f2d0d1c
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/komodo.yml
+++ b/vendor-specs/google_devices/komodo.yml
@@ -3292,7 +3292,7 @@ proprietary/system_ext/priv-app/ril-extension/ril-extension.apk: 2321acf46b18a5a
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 6f41fbd3e9ae919f65b4aa03a4decf37302c4e2edfccfcfd0dc374c762a7ddd4
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 337bf6c8e8909dafa4518d2d1819f07a42381db7847ded88036d40afc5cd653b
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 647486c091efdd5ed20ddd9065f9252151d9594b145745752598dfbc8194aafa
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 32b32875f21fbdc9263046ab5359b941daf24f85c43d12fb13a272cc845d5bee
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 021d51c86b117fc640f5c8fce17f8ff4890d66058d285202915c70e549c9ae23
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/lynx.yml
+++ b/vendor-specs/google_devices/lynx.yml
@@ -3098,7 +3098,7 @@ proprietary/system_ext/priv-app/ShannonRcs/ShannonRcs.apk: 4b2f1188c8a7b47a14670
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 2c8c883a4a703e9420ea79b246b5157e057a762c42fbfcf2c553a78e8155f335
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 39a813763737254571d49fd5a0cba82949fb76e51c60f065b47d637430e43cc5
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 5eb2ff432b75edfc18ec9d3898e8ec86d69dd30a1b1c439030014fc1dc964df8
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 4b1493b8a559fa6d56c8f43dc9831728a306a9b8425311e01b04dee262cbfbac
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 9d55e95848c0a9277aefee0f17e9c54f8696662be735635f1567ac43cb55ebb3
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/mustang.yml
+++ b/vendor-specs/google_devices/mustang.yml
@@ -3092,7 +3092,7 @@ proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: c0429e2130a82731a0cd0c73d57a7a1bbec1681939a7edf54224a351d202be3b
 proprietary/vendor/apex/com.google.muzel.hardware.threadnetwork.apex: 1ba74d6686256ba2436dadf22a98bf2f9816711b58fa01f200f98e63abb291c3
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: d06f9e283d0c4fae61cc780b961cb5d88147cecccd7aac7a8866e7d0ec50053e
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: abb9fe846f89248cac58b64fb9d7b6f159620a99a71c0ec749221b51ae06fbfa
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 045dfff9f18d3bdbf80a11559483dda37dd66eda157076c3b033c441600d8f7e
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 346c3b60dfc136d502ddc8ebc3e148a49f2e34d594c4abd3eb77242883340a0d
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/oriole.yml
+++ b/vendor-specs/google_devices/oriole.yml
@@ -3186,7 +3186,7 @@ proprietary/system_ext/priv-app/ShannonRcs/ShannonRcs.apk: abfc03fdb2657c152bebf
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 3b2fcfa22277b76469114147283a2c40dea55380b4eafa24aed2efff298a1642
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 17e64a631aa69e952fbfaae22da5426896b4f72a4048a183170cfed3eb18cc95
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: d7cf547014e56775eb9a54eac5b5ee48b037c8b5f5f13e472e91cad1d91736ce
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: c40a934898dc1112f6d65eaafc97f4a0b82144f6421bf9965bfb1d0c20cbd4bd
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 958e745e7918ce9ca82b6fb9ad79ffa7a8bcd6d523cf4fe4307733828b64099b
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/panther.yml
+++ b/vendor-specs/google_devices/panther.yml
@@ -3538,7 +3538,7 @@ proprietary/system_ext/priv-app/ShannonRcs/ShannonRcs.apk: cf41e3171928f1780c391
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 57e5135933f0bdb0f13ed7ecd02f91c4f081a9488fcc9401aa53f7e9a287135b
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 944f46b2865463a32ea688e300c1e18e13a511b31fe654fe4ba9b1c03fc5b2e5
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: f442944ce34b2489b7a749ec8102185882a51bcbdc17506077af77d91b6e6e3f
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 168a31c52a6e3474fcb32a6f97d29fc7bf25ffc679f7faa92ac63b35b55e8597
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 0cb00f2a080d7cda201f5258822afe06d2b15dab2fb150beddadcd08f9e58503
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/rango.yml
+++ b/vendor-specs/google_devices/rango.yml
@@ -3348,7 +3348,7 @@ proprietary/system_ext/priv-app/ril-extension/ril-extension.apk: 4f2dbd7a82340a4
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: b36cd713759fd037a9fd3dba25469c4d94065b7f57910fe96ea5c7bf1ba5168c
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 90ba81f7d51288376ea70749f2948349bf68094db9955e103d612702a12b9734
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: c847d20e387936675e576769d20b77a0ee5b160618e447b6f39f402a06b5f321
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 0e023b0bbe678510486afb6f95819abfe3b933f79260ffb4ac879d505e4d1b3a
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 9de7a45465647c5e0e5f5ab68eeea4987042ee6ab9a871803173265e040c2e21
 proprietary/vendor/apex/com.google.rango.hardware.threadnetwork.apex: bf077e63121b6c2fdd8f35469523725a47acc79b02847adb59226de3ce5211fe

--- a/vendor-specs/google_devices/raven.yml
+++ b/vendor-specs/google_devices/raven.yml
@@ -3358,7 +3358,7 @@ proprietary/system_ext/priv-app/UwbVendorService/UwbVendorService.apk: e35a9d055
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: c254a8e1d879fef4b8ac2a6c2972d46d1af3c4300b0ba34c40c6b980631973be
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 80c3e2d93e9f7f78d188c6b7241e2a8e4cec52177d73b31f86edffcec7cfe82a
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 55d410b0ab5ec9d09737e1bdb995da567a0f95e4c25c4afd3fbe68d8b2fadedc
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 98f0495b032b135cc6fea9ebd454fde7d39b3b32e35f062bd1447bce0b89c972
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: b0b9c4654d4ba3873a16ff2d10eae41374f699ae03e32ec7c5e72dc301978e88
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/shiba.yml
+++ b/vendor-specs/google_devices/shiba.yml
@@ -3056,7 +3056,7 @@ proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.hardware.biometrics.fingerprint.apex: 084e6a27a66eb0b789b6c0b6e556d9621c98f300d5dc7717a8fd0a73c348761a
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: b1eed4643c33e91c182a6f8a9b3a182ed2f3d4d448b16ccc69dfef1a4aeedf2b
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: b7492d69a4dd64f7916e5d577ea7c696fe700bf044ca2cc624c2baddcbe52558
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: bb733f6d235c0464f96fd95f5ee7399f351934f9cf58fa79fc374b1179619758
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 95c3d3628b56943257e3b9414c098b26ea8a26b8c87e53ee08ac116f92a37e26
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 62ab2b0d82de7950390b10171e0fabe7468124461e5458a650ce8bc4c7640647
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/tangorpro.yml
+++ b/vendor-specs/google_devices/tangorpro.yml
@@ -4955,7 +4955,7 @@ proprietary/system_ext/priv-app/UwbVendorService/UwbVendorService.apk: 33d1f45a3
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: ba0e3533d48a4fccc6a63ba8ee7520cfacae83e0f9332c8b8e5659cab134c092
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: e8e384e1b6cb56e771f4d72650bf2ca8666eb52f01b9a086b52b8162d99d20e0
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 3a7068f4949088740d620384a0dd8f78eced8ce7244b0d938c96625255cd0ee8
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: a4e45dc95e50a5469c175857426cb5e3faf028903f5bc04d6f8a3e96a851d012
 proprietary/vendor/bin: dir
 proprietary/vendor/bin/aocd: 37ed95e0b46a73c30205f6527dd37aa4da93eca348a423b0d27fdb605be6484c

--- a/vendor-specs/google_devices/tegu.yml
+++ b/vendor-specs/google_devices/tegu.yml
@@ -3096,7 +3096,7 @@ proprietary/system_ext/priv-app/ril-extension/ril-extension.apk: 30c0f0e1daf4ddd
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: bc79a54655f4ef62d118c5b30d4599d885a7df73c9fcbbcc01fc7e20521f1dc5
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 0133e01e008e388575c7402d6e3cbf778d0dcabb93dfe642432d524d99b12dbd
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: e3cd5afe288a7caa8f5083fdb42d4957c94ca0ef760ef64ae0d888d010496f89
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 9c94bd1feafb01222cd27deb56df426d25dfc7b99e7b25a510180b23d30015a2
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: f4518cf5d54f86c6204a89f23864b220bfed9ec923632b85a8289b16e0968997
 proprietary/vendor/bin: dir

--- a/vendor-specs/google_devices/tokay.yml
+++ b/vendor-specs/google_devices/tokay.yml
@@ -3281,7 +3281,7 @@ proprietary/system_ext/priv-app/ril-extension/ril-extension.apk: 2bc261c1d90a367
 proprietary/vendor: dir
 proprietary/vendor/apex: dir
 proprietary/vendor/apex/com.google.android.widevine-13130248.apex: 9848976454f3bf23ef1d38e5fe2c9b4fcbcd9827447db6495660aa3fb382f0cb
-proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 105fd2e0573a69dd36b3a289a048fa146120d0aed25bc953d9a8bf1d9760ce31
+proprietary/vendor/apex/com.google.pixel.camera.hal.apex: 6051ba1ad9f034db26fa32428756ee959dddd02db9def52c9c5a1241ad535897
 proprietary/vendor/apex/com.google.pixel.euicc.update.apex: 1f97c6e9cf8bc52d0c32ce1c93285df9d4cec9041fcea6e7dee13d2d5e3ff5c1
 proprietary/vendor/apex/com.google.pixel.wifi.ext.apex: 2d46c125d4aad1bf92e63db2b2f62452a6a1ddc17f7a93a5ecdc33f895707217
 proprietary/vendor/bin: dir


### PR DESCRIPTION
Rear camera (BOITATA) did not work for Pixel 8 until we backport this. Oddly enough, Pixel 8
Pro and 8a didn't have this issue, and other devices don't seem to have it either.