### PR TITLE
generate-all: support keeping certain unpacked images after successful generation

### DIFF
--- a/src/commands/generate-all.ts
+++ b/src/commands/generate-all.ts
@@ -27,6 +27,7 @@ import {
   DeviceBuildId,
   DeviceConfig,
   getDeviceBuildId,
+  loadDeviceConfigs,
   loadDeviceConfigs2,
 } from '../config/device'
 import {
@@ -49,7 +50,7 @@ import {
   writeEnvsetupCommands,
 } from '../frontend/generate'
 import { writeReadme } from '../frontend/readme'
-import { DeviceImages, prepareDeviceImages } from '../frontend/source'
+import { deleteUnpackedDeviceImages, DeviceImages, prepareDeviceImages } from '../frontend/source'
 import { BuildIndex, ImageType, loadBuildIndex } from '../images/build-index'
 import { processApks } from '../processor/apk-processor'
 import { processSystemServerClassPaths } from '../processor/classpath'
@@ -195,6 +196,13 @@ export default class GenerateFull extends Command {
 
     doNotDownloadCarrierSettings: Flags.boolean({}),
 
+    devicesToKeepUnpacked: Flags.string({
+      char: 'k',
+      description: `Device or DeviceList config paths or names of unpacked images to keep. If this is set, other devices will have their unpacked images removed on successful vendor module generation`,
+      multiple: true,
+      default: [],
+    }),
+
     ...DEVICE_CONFIGS_FLAG_WITH_BUILD_ID,
   }
 
@@ -203,6 +211,13 @@ export default class GenerateFull extends Command {
 
     let devices = await loadDeviceConfigs2(flags)
     let index: BuildIndex = await loadBuildIndex()
+
+    const devicesToKeepUnpacked = (flags.devicesToKeepUnpacked.length > 0)
+      ? new Set(
+          (await loadDeviceConfigs2({ devices: flags.devicesToKeepUnpacked }))
+            .map(config => config.device.name)
+        )
+      : undefined;
 
     await forEachDevice(
       devices,
@@ -307,7 +322,14 @@ export default class GenerateFull extends Command {
           }
         }
         await writeVersionCheckFile(config, vendorDirs, flags.noVerify)
-        log('Generated vendor module at ' + vendorDirs.out)
+        
+        const baseMsg = 'Generated vendor module at ' + vendorDirs.out
+        if (devicesToKeepUnpacked && !devicesToKeepUnpacked.has(config.device.name)) {
+          log(baseMsg + ', deleting unpacked images')
+          await deleteUnpackedDeviceImages(images);
+        } else {
+          log(baseMsg)
+        }
       },
       config => config.device.name,
     )

--- a/src/frontend/source.ts
+++ b/src/frontend/source.ts
@@ -113,14 +113,28 @@ export async function prepareDeviceImages(
   return imagesMap
 }
 
-const unpackConcurrency = parseInt(process.env['ADEVTOOL_UNPACK_CONCURRENCY'] ?? '10')
-const unpackSemaphore = new Semaphore(unpackConcurrency)
-
-async function unpackImage(imageToUnpack: DeviceImage, destDir: string) {
+async function deleteNonTempUnpackedImagesDir(destDir: string) {
   if (await isDirectory(destDir)) {
     await spawnAsyncNoOut('chmod', ['-R', 'u+w', destDir])
     await spawnAsyncNoOut('rm', ['-r', destDir])
   }
+}
+
+export async function deleteUnpackedDeviceImages(imagesMap: Map<DeviceBuildId, DeviceImages>) {
+  for (const images of imagesMap.values()) {
+    const dir = images.unpackedFactoryImageDir;
+    if (!dir) {
+      continue;
+    }
+    await deleteNonTempUnpackedImagesDir(dir);
+  }
+}
+
+const unpackConcurrency = parseInt(process.env['ADEVTOOL_UNPACK_CONCURRENCY'] ?? '10')
+const unpackSemaphore = new Semaphore(unpackConcurrency)
+
+async function unpackImage(imageToUnpack: DeviceImage, destDir: string) {
+  await deleteNonTempUnpackedImagesDir(destDir);
 
   let destTmpDir = destDir + '-tmp'
 


### PR DESCRIPTION
Unpacked images take up a lot of space. Add an option to remove unpacked images after successful vendor module generation. This is useful if generating vendor-{specs,skels} for all devices is desired but storage is constrained. e.g., if you expect to be regenerating vendor modules often for only the devices you own, you can keep only their unpacked images while you generate vendor-{specs,skels} for all devices.

For example,

```
$ adevtool generate-all -k caiman tokay -d caiman tokay bluejay
Devices: caiman | tokay | bluejay
Generated vendor module at vendor/google_devices/tokay
Generated vendor module at vendor/google_devices/caiman
Generated vendor module at vendor/google_devices/bluejay, deleting unpacked images

$ adevtool generate-all -k vendor/adevtool/config/device/pixel-gen9.yml -d caiman tokay bluejay
Devices: caiman | tokay | bluejay
Generated vendor module at vendor/google_devices/tokay
Generated vendor module at vendor/google_devices/caiman
Generated vendor module at vendor/google_devices/bluejay, deleting unpacked images

$ adevtool generate-all -d caiman tokay bluejay
Generated vendor module at vendor/google_devices/tokay
Generated vendor module at vendor/google_devices/caiman
Generated vendor module at vendor/google_devices/bluejay
```