### PR TITLE
SELinux: backport hal_camera_default camerax_extensions_prop access from QPR3

### DIFF
--- a/config/mk/google_devices/common/sepolicy/vendor/hal_camera_default.te
+++ b/config/mk/google_devices/common/sepolicy/vendor/hal_camera_default.te
@@ -1,0 +1,1 @@
+get_prop(hal_camera_default, camerax_extensions_prop)


### PR DESCRIPTION
We're backporting Pixel Camera HAL from QPR3. This logcat line appears during boot:

`W android.hardwar: type=1400 audit(0.0:5): avc:  denied  { read } for  name="u:object_r:camerax_extensions_prop:s0" dev="tmpfs" ino=129 scontext=u:r:hal_camera_default:s0 tcontext=u:object_r:camerax_extensions_prop:s0 tclass=file permissive=0`

This can be found in CP1A images but not in earlier images:

shiba-CP1A.260305.018:

```
$ rg "hal_camera_default camerax_extensions_pro"
vendor/etc/selinux/vendor_sepolicy.cil
2373:(allow hal_camera_default camerax_extensions_prop_202504 (file (read getattr map open)))
$
```

shiba-BP4A.260205.001:

```
$ rg "hal_camera_default camerax_extensions_pro"
$
```