### PR TITLE
stallion: ensure V4 of USB HAL NDK is actually backported

### DIFF
--- a/config/device/stallion.yml
+++ b/config/device/stallion.yml
@@ -16,6 +16,7 @@ backport_files:
     - bin/modem_logging_control
     - bin/pixelstats-vendor
     - lib64/chremetrics-cpp.so
+    - lib64/android.hardware.usb-V4-ndk.so
     - lib64/com.google.edgetpu_app_service-V6-ndk.so
     - lib64/libjsoncpp.so
     - lib64/libpixelstats.so
@@ -27,7 +28,6 @@ extra_packages:
   # needed by vendor/bin/hw/android.hardware.contexthub-service.generic
   - android.hardware.bluetooth.socket-V1-ndk.vendor # hardware/interfaces/bluetooth/socket/aidl | vendor/lib64/android.hardware.bluetooth.socket-V1-ndk.so
   - android.hardware.bluetooth.ranging-V2-ndk.vendor # hardware/interfaces/bluetooth/ranging/aidl | vendor/lib64/android.hardware.bluetooth.ranging-V2-ndk.so
-  - android.hardware.usb-V4-ndk.vendor # hardware/interfaces/usb/aidl | vendor/lib64/android.hardware.usb-V4-ndk.so
 
 includes:
   - common/gen9pixel.yml
@@ -558,6 +558,7 @@ filters:
     - vendor/etc/init/hw/init.stallion.rc
     - vendor/firmware/CPS4041_A0_06.bin
     - vendor/firmware/g7b.app
+    - vendor/lib64/android.hardware.usb-V4-ndk.so
     - vendor/lib64/libjsoncpp.so
     - vendor/lib64/libprotobuf-cpp-full-21.12.so
     - vendor/lib64/libprotobuf-cpp-lite-21.12.so

--- a/src/frontend/generate.ts
+++ b/src/frontend/generate.ts
@@ -492,9 +492,11 @@ export async function generateBuildFiles(
           copyFiles.push(blobToFileCopy(entry, dirs.proprietary))
           continue
         }
-        if (resolvedName === 'libjsoncpp' && config.device.name === 'stallion') {
-          copyFiles.push(blobToFileCopy(entry, dirs.proprietary))
-          continue
+        if (config.device.name === 'stallion') {
+          if (resolvedName === 'libjsoncpp' || resolvedName === 'android.hardware.usb-V4-ndk') {
+            copyFiles.push(blobToFileCopy(entry, dirs.proprietary))
+            continue
+          }
         }
       }
 

--- a/vendor-skels/google_devices/stallion/stallion.mk
+++ b/vendor-skels/google_devices/stallion/stallion.mk
@@ -922,8 +922,7 @@ PRODUCT_PACKAGES += \
 # extra packages
 PRODUCT_PACKAGES += \
     android.hardware.bluetooth.socket-V1-ndk.vendor \
-    android.hardware.bluetooth.ranging-V2-ndk.vendor \
-    android.hardware.usb-V4-ndk.vendor
+    android.hardware.bluetooth.ranging-V2-ndk.vendor
 
 # inclusion of symlinks
 PRODUCT_PACKAGES += \
@@ -4597,6 +4596,7 @@ PRODUCT_COPY_FILES += \
     vendor/google_devices/stallion/proprietary/vendor/firmware/uecapconfig/WINDTRE_7893983720033341017.binarypb:$(TARGET_COPY_OUT_VENDOR)/firmware/uecapconfig/WINDTRE_7893983720033341017.binarypb \
     vendor/google_devices/stallion/proprietary/vendor/firmware/uecapconfig/WINDTRE_8011870100005042994.binarypb:$(TARGET_COPY_OUT_VENDOR)/firmware/uecapconfig/WINDTRE_8011870100005042994.binarypb \
     vendor/google_devices/stallion/proprietary/vendor/firmware/uecapconfig/WINDTRE_8851100888085059077.binarypb:$(TARGET_COPY_OUT_VENDOR)/firmware/uecapconfig/WINDTRE_8851100888085059077.binarypb \
+    vendor/google_devices/stallion/proprietary/vendor/lib64/android.hardware.usb-V4-ndk.so:$(TARGET_COPY_OUT_VENDOR)/lib64/android.hardware.usb-V4-ndk.so \
     vendor/google_devices/stallion/proprietary/vendor/lib64/libaconfig_storage_read_api_cc.so:$(TARGET_COPY_OUT_VENDOR)/lib64/libaconfig_storage_read_api_cc.so \
     vendor/google_devices/stallion/proprietary/vendor/lib64/libc++.so:$(TARGET_COPY_OUT_VENDOR)/lib64/libc++.so \
     vendor/google_devices/stallion/proprietary/vendor/lib64/libjsoncpp.so:$(TARGET_COPY_OUT_VENDOR)/lib64/libjsoncpp.so \

--- a/vendor-specs/google_devices/stallion.yml
+++ b/vendor-specs/google_devices/stallion.yml
@@ -6376,6 +6376,7 @@ proprietary/vendor/lib64/android.hardware.power.stats-impl.gs-common.so: 3918a51
 proprietary/vendor/lib64/android.hardware.power.stats-impl.pixel.so: 79b70213ee0f4e5481d2ea71038582d8079fe4a4ebada5e0923bb9d56de69594
 proprietary/vendor/lib64/android.hardware.power.stats-impl.zumapro.so: bf619aed84e2aa01b33ecdc8e11f385aee27bb9341dab37b2117cd90482d23f2
 proprietary/vendor/lib64/android.hardware.security.keymint-impl.nos.so: 24cd02b048cb82f8341dcad02a160b9806aed144f9f1453c27d27e359dfc64d1
+proprietary/vendor/lib64/android.hardware.usb-V4-ndk.so: f92768902adbd15cb7e6b1047f93af076df50e73691efd228dda083d4dfda1f6
 proprietary/vendor/lib64/android.hardware.weaver-bridge.nos.so: 91decc40172970d62c3fefc08e3853bd38215bd67fe25a6791a7aec5556a28a4
 proprietary/vendor/lib64/android.hardware.weaver-impl.nos.so: 5aeb35cb801f54acba4bcb074085017acd85824f3abf0f3deac7475462531eda
 proprietary/vendor/lib64/android.hardware.weaver2-impl.nos.so: 30d8b33e316722c967a1a413e59fca36a274979aac0d613f36cc0b60682a09d0
@@ -6608,7 +6609,7 @@ sepolicy/vendor/sepolicy_ext_recovery.cil: 589c8852f4733b8caa13307138a59428d565e
 sepolicy/vendor/service_contexts: bc8c5953e9546a892298a30e5d5653cbcf34472fea75459e04164238600f3dc9
 sepolicy/vendor/types.te: 8e209bf6fde4d1db07468144205f231c297c98c98c40a447943e5781f5b0374f
 sepolicy/vendor/vndservice_contexts: a798285f683386edf3a64d6db4a5f3424ffefccafd67920af418ebb020cfee30
-stallion.mk: 4ab5dae0712bd10c711947bf8318daff77f75bd21e0b2c2b2203bccef02cdef6
+stallion.mk: 061339bf463226defd0ecdedd15febc4e191e2cff51217b449b3d0e73331dd43
 sysconfig: dir
 sysconfig/Android.bp: 303d8180cf9e1689aa6751ae3e8e120b8fad031d0e818de31ef444c26cc93348
 sysconfig/product: dir


### PR DESCRIPTION
AOSP in 16-qpr2 does not have V4 in hardware/interfaces/usb/aidl/Android.bp. It only goes up to V3. Specifying the android.hardware.usb-V4-ndk.vendor package appeared to make AOSP use V3 and just relabel it as V4 (file sizes between the two versions were the same).