### PR TITLE
remove android.hardware.telephony.satellite feature declaration

### DIFF
--- a/config/device/common/sysconfig-exclusion.yml
+++ b/config/device/common/sysconfig-exclusion.yml
@@ -43,6 +43,7 @@ sysconfig_exclusions:
       <component class="com.android.storagemanager.deletionhelper.DeletionHelperActivity" enabled="false"/>
     </component-override>
   - <feature name="android.hardware.biometrics.face"/>
+  - <feature name="android.hardware.telephony.satellite"/>
   - <feature name="android.software.communal_mode"/>
   - <feature name="android.software.game_service"/>
   - <feature name="android.software.wallet_location_based_suggestions"/>

--- a/config/device/common/sysconfig-inclusion.yml
+++ b/config/device/common/sysconfig-inclusion.yml
@@ -9,7 +9,6 @@ sysconfig_inclusions:
   - <feature name="android.hardware.strongbox_keystore" version="300"/>
   - <feature name="android.hardware.telephony.euicc"/>
   - <feature name="android.hardware.telephony.euicc.mep"/>
-  - <feature name="android.hardware.telephony.satellite"/>
   - <feature name="android.hardware.uwb"/>
   - <feature name="android.hardware.vulkan.compute" version="0"/>
   - <feature name="android.hardware.vulkan.level" version="1"/>

--- a/vendor-skels/google_devices/blazer/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
+++ b/vendor-skels/google_devices/blazer/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<permissions>
-  <feature name="android.hardware.telephony.satellite"/>
-</permissions>

--- a/vendor-skels/google_devices/caiman/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
+++ b/vendor-skels/google_devices/caiman/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<permissions>
-  <feature name="android.hardware.telephony.satellite"/>
-</permissions>

--- a/vendor-skels/google_devices/comet/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
+++ b/vendor-skels/google_devices/comet/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<permissions>
-  <feature name="android.hardware.telephony.satellite"/>
-</permissions>

--- a/vendor-skels/google_devices/frankel/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
+++ b/vendor-skels/google_devices/frankel/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<permissions>
-  <feature name="android.hardware.telephony.satellite"/>
-</permissions>

--- a/vendor-skels/google_devices/komodo/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
+++ b/vendor-skels/google_devices/komodo/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<permissions>
-  <feature name="android.hardware.telephony.satellite"/>
-</permissions>

--- a/vendor-skels/google_devices/mustang/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
+++ b/vendor-skels/google_devices/mustang/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<permissions>
-  <feature name="android.hardware.telephony.satellite"/>
-</permissions>

--- a/vendor-skels/google_devices/rango/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
+++ b/vendor-skels/google_devices/rango/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<permissions>
-  <feature name="android.hardware.telephony.satellite"/>
-</permissions>

--- a/vendor-skels/google_devices/stallion/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
+++ b/vendor-skels/google_devices/stallion/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<permissions>
-  <feature name="android.hardware.telephony.satellite"/>
-</permissions>

--- a/vendor-skels/google_devices/tegu/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
+++ b/vendor-skels/google_devices/tegu/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<permissions>
-  <feature name="android.hardware.telephony.satellite"/>
-</permissions>

--- a/vendor-skels/google_devices/tokay/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
+++ b/vendor-skels/google_devices/tokay/sysconfig/product/permissions/android.hardware.telephony.satellite.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<permissions>
-  <feature name="android.hardware.telephony.satellite"/>
-</permissions>

--- a/vendor-specs/google_devices/blazer.yml
+++ b/vendor-specs/google_devices/blazer.yml
@@ -6684,7 +6684,6 @@ sysconfig/product/default-permissions/default-permissions.xml: d7fbe7e60926dde54
 sysconfig/product/permissions: dir
 sysconfig/product/permissions/android.hardware.telephony.euicc.mep.xml: 5f3a2ee052a41e9f42110057cd60a87117a22d7f358571199c44f1929030c412
 sysconfig/product/permissions/android.hardware.telephony.euicc.xml: 211bb53d65e73aedfb0a9afb4d65e5891417811ae28d2438324d6b3f3b5bde0d
-sysconfig/product/permissions/android.hardware.telephony.satellite.xml: e18ea780088a89016a5115e7624da6cb21ec2747a3033b1dd0ca7c66fc4002c5
 sysconfig/product/permissions/androidx.camera.extensions.impl.xml: 2f608136ec90b7331625c1cd63965fe4d2227affe2db331f00e3200aa1d81a98
 sysconfig/product/permissions/com.google.android.dialer.support.xml: 42c0ad27676d0b7d21150d6586672b2567ac272f5f24657110914b090631bdb7
 sysconfig/product/permissions/com.google.pixel.camera.connectivity.impl.xml: 2e4338cd3a461a36a6a72ac8fbafa76ea8f158b160766b4d3bd2d6e982eb6e96

--- a/vendor-specs/google_devices/caiman.yml
+++ b/vendor-specs/google_devices/caiman.yml
@@ -6925,7 +6925,6 @@ sysconfig/product/default-permissions/default-permissions.xml: d7fbe7e60926dde54
 sysconfig/product/permissions: dir
 sysconfig/product/permissions/android.hardware.telephony.euicc.mep.xml: 5f3a2ee052a41e9f42110057cd60a87117a22d7f358571199c44f1929030c412
 sysconfig/product/permissions/android.hardware.telephony.euicc.xml: 211bb53d65e73aedfb0a9afb4d65e5891417811ae28d2438324d6b3f3b5bde0d
-sysconfig/product/permissions/android.hardware.telephony.satellite.xml: e18ea780088a89016a5115e7624da6cb21ec2747a3033b1dd0ca7c66fc4002c5
 sysconfig/product/permissions/androidx.camera.extensions.impl.xml: 2f608136ec90b7331625c1cd63965fe4d2227affe2db331f00e3200aa1d81a98
 sysconfig/product/permissions/com.google.android.dialer.support.xml: 42c0ad27676d0b7d21150d6586672b2567ac272f5f24657110914b090631bdb7
 sysconfig/product/permissions/com.google.pixel.camera.connectivity.impl.xml: 2e4338cd3a461a36a6a72ac8fbafa76ea8f158b160766b4d3bd2d6e982eb6e96

--- a/vendor-specs/google_devices/comet.yml
+++ b/vendor-specs/google_devices/comet.yml
@@ -7089,7 +7089,6 @@ sysconfig/product/default-permissions/default-permissions.xml: d7fbe7e60926dde54
 sysconfig/product/permissions: dir
 sysconfig/product/permissions/android.hardware.telephony.euicc.mep.xml: 5f3a2ee052a41e9f42110057cd60a87117a22d7f358571199c44f1929030c412
 sysconfig/product/permissions/android.hardware.telephony.euicc.xml: 211bb53d65e73aedfb0a9afb4d65e5891417811ae28d2438324d6b3f3b5bde0d
-sysconfig/product/permissions/android.hardware.telephony.satellite.xml: e18ea780088a89016a5115e7624da6cb21ec2747a3033b1dd0ca7c66fc4002c5
 sysconfig/product/permissions/androidx.camera.extensions.impl.xml: 2f608136ec90b7331625c1cd63965fe4d2227affe2db331f00e3200aa1d81a98
 sysconfig/product/permissions/com.google.android.dialer.support.xml: 42c0ad27676d0b7d21150d6586672b2567ac272f5f24657110914b090631bdb7
 sysconfig/product/permissions/com.google.pixel.camera.connectivity.impl.xml: 2e4338cd3a461a36a6a72ac8fbafa76ea8f158b160766b4d3bd2d6e982eb6e96

--- a/vendor-specs/google_devices/frankel.yml
+++ b/vendor-specs/google_devices/frankel.yml
@@ -6651,7 +6651,6 @@ sysconfig/product/default-permissions/default-permissions.xml: d7fbe7e60926dde54
 sysconfig/product/permissions: dir
 sysconfig/product/permissions/android.hardware.telephony.euicc.mep.xml: 5f3a2ee052a41e9f42110057cd60a87117a22d7f358571199c44f1929030c412
 sysconfig/product/permissions/android.hardware.telephony.euicc.xml: 211bb53d65e73aedfb0a9afb4d65e5891417811ae28d2438324d6b3f3b5bde0d
-sysconfig/product/permissions/android.hardware.telephony.satellite.xml: e18ea780088a89016a5115e7624da6cb21ec2747a3033b1dd0ca7c66fc4002c5
 sysconfig/product/permissions/androidx.camera.extensions.impl.xml: 2f608136ec90b7331625c1cd63965fe4d2227affe2db331f00e3200aa1d81a98
 sysconfig/product/permissions/com.google.android.dialer.support.xml: 42c0ad27676d0b7d21150d6586672b2567ac272f5f24657110914b090631bdb7
 sysconfig/product/permissions/com.google.pixel.camera.connectivity.impl.xml: 2e4338cd3a461a36a6a72ac8fbafa76ea8f158b160766b4d3bd2d6e982eb6e96

--- a/vendor-specs/google_devices/komodo.yml
+++ b/vendor-specs/google_devices/komodo.yml
@@ -6925,7 +6925,6 @@ sysconfig/product/default-permissions/default-permissions.xml: d7fbe7e60926dde54
 sysconfig/product/permissions: dir
 sysconfig/product/permissions/android.hardware.telephony.euicc.mep.xml: 5f3a2ee052a41e9f42110057cd60a87117a22d7f358571199c44f1929030c412
 sysconfig/product/permissions/android.hardware.telephony.euicc.xml: 211bb53d65e73aedfb0a9afb4d65e5891417811ae28d2438324d6b3f3b5bde0d
-sysconfig/product/permissions/android.hardware.telephony.satellite.xml: e18ea780088a89016a5115e7624da6cb21ec2747a3033b1dd0ca7c66fc4002c5
 sysconfig/product/permissions/androidx.camera.extensions.impl.xml: 2f608136ec90b7331625c1cd63965fe4d2227affe2db331f00e3200aa1d81a98
 sysconfig/product/permissions/com.google.android.dialer.support.xml: 42c0ad27676d0b7d21150d6586672b2567ac272f5f24657110914b090631bdb7
 sysconfig/product/permissions/com.google.pixel.camera.connectivity.impl.xml: 2e4338cd3a461a36a6a72ac8fbafa76ea8f158b160766b4d3bd2d6e982eb6e96

--- a/vendor-specs/google_devices/mustang.yml
+++ b/vendor-specs/google_devices/mustang.yml
@@ -6685,7 +6685,6 @@ sysconfig/product/default-permissions/default-permissions.xml: d7fbe7e60926dde54
 sysconfig/product/permissions: dir
 sysconfig/product/permissions/android.hardware.telephony.euicc.mep.xml: 5f3a2ee052a41e9f42110057cd60a87117a22d7f358571199c44f1929030c412
 sysconfig/product/permissions/android.hardware.telephony.euicc.xml: 211bb53d65e73aedfb0a9afb4d65e5891417811ae28d2438324d6b3f3b5bde0d
-sysconfig/product/permissions/android.hardware.telephony.satellite.xml: e18ea780088a89016a5115e7624da6cb21ec2747a3033b1dd0ca7c66fc4002c5
 sysconfig/product/permissions/androidx.camera.extensions.impl.xml: 2f608136ec90b7331625c1cd63965fe4d2227affe2db331f00e3200aa1d81a98
 sysconfig/product/permissions/com.google.android.dialer.support.xml: 42c0ad27676d0b7d21150d6586672b2567ac272f5f24657110914b090631bdb7
 sysconfig/product/permissions/com.google.pixel.camera.connectivity.impl.xml: 2e4338cd3a461a36a6a72ac8fbafa76ea8f158b160766b4d3bd2d6e982eb6e96

--- a/vendor-specs/google_devices/rango.yml
+++ b/vendor-specs/google_devices/rango.yml
@@ -6971,7 +6971,6 @@ sysconfig/product/default-permissions/default-permissions.xml: d7fbe7e60926dde54
 sysconfig/product/permissions: dir
 sysconfig/product/permissions/android.hardware.telephony.euicc.mep.xml: 5f3a2ee052a41e9f42110057cd60a87117a22d7f358571199c44f1929030c412
 sysconfig/product/permissions/android.hardware.telephony.euicc.xml: 211bb53d65e73aedfb0a9afb4d65e5891417811ae28d2438324d6b3f3b5bde0d
-sysconfig/product/permissions/android.hardware.telephony.satellite.xml: e18ea780088a89016a5115e7624da6cb21ec2747a3033b1dd0ca7c66fc4002c5
 sysconfig/product/permissions/androidx.camera.extensions.impl.xml: 2f608136ec90b7331625c1cd63965fe4d2227affe2db331f00e3200aa1d81a98
 sysconfig/product/permissions/com.google.android.dialer.support.xml: 42c0ad27676d0b7d21150d6586672b2567ac272f5f24657110914b090631bdb7
 sysconfig/product/permissions/com.google.pixel.camera.connectivity.impl.xml: 2e4338cd3a461a36a6a72ac8fbafa76ea8f158b160766b4d3bd2d6e982eb6e96

--- a/vendor-specs/google_devices/stallion.yml
+++ b/vendor-specs/google_devices/stallion.yml
@@ -6618,7 +6618,6 @@ sysconfig/product/default-permissions/default-permissions.xml: d7fbe7e60926dde54
 sysconfig/product/permissions: dir
 sysconfig/product/permissions/android.hardware.telephony.euicc.mep.xml: 5f3a2ee052a41e9f42110057cd60a87117a22d7f358571199c44f1929030c412
 sysconfig/product/permissions/android.hardware.telephony.euicc.xml: 211bb53d65e73aedfb0a9afb4d65e5891417811ae28d2438324d6b3f3b5bde0d
-sysconfig/product/permissions/android.hardware.telephony.satellite.xml: e18ea780088a89016a5115e7624da6cb21ec2747a3033b1dd0ca7c66fc4002c5
 sysconfig/product/permissions/androidx.camera.extensions.impl.xml: 2f608136ec90b7331625c1cd63965fe4d2227affe2db331f00e3200aa1d81a98
 sysconfig/product/permissions/com.google.android.dialer.support.xml: 42c0ad27676d0b7d21150d6586672b2567ac272f5f24657110914b090631bdb7
 sysconfig/product/permissions/com.google.pixel.camera.connectivity.impl.xml: 2e4338cd3a461a36a6a72ac8fbafa76ea8f158b160766b4d3bd2d6e982eb6e96

--- a/vendor-specs/google_devices/tegu.yml
+++ b/vendor-specs/google_devices/tegu.yml
@@ -5421,7 +5421,6 @@ sysconfig/product/default-permissions/default-permissions.xml: d7fbe7e60926dde54
 sysconfig/product/permissions: dir
 sysconfig/product/permissions/android.hardware.telephony.euicc.mep.xml: 5f3a2ee052a41e9f42110057cd60a87117a22d7f358571199c44f1929030c412
 sysconfig/product/permissions/android.hardware.telephony.euicc.xml: 211bb53d65e73aedfb0a9afb4d65e5891417811ae28d2438324d6b3f3b5bde0d
-sysconfig/product/permissions/android.hardware.telephony.satellite.xml: e18ea780088a89016a5115e7624da6cb21ec2747a3033b1dd0ca7c66fc4002c5
 sysconfig/product/permissions/androidx.camera.extensions.impl.xml: 2f608136ec90b7331625c1cd63965fe4d2227affe2db331f00e3200aa1d81a98
 sysconfig/product/permissions/com.google.android.dialer.support.xml: 42c0ad27676d0b7d21150d6586672b2567ac272f5f24657110914b090631bdb7
 sysconfig/product/permissions/com.google.pixel.camera.connectivity.impl.xml: 2e4338cd3a461a36a6a72ac8fbafa76ea8f158b160766b4d3bd2d6e982eb6e96

--- a/vendor-specs/google_devices/tokay.yml
+++ b/vendor-specs/google_devices/tokay.yml
@@ -6895,7 +6895,6 @@ sysconfig/product/default-permissions/default-permissions.xml: d7fbe7e60926dde54
 sysconfig/product/permissions: dir
 sysconfig/product/permissions/android.hardware.telephony.euicc.mep.xml: 5f3a2ee052a41e9f42110057cd60a87117a22d7f358571199c44f1929030c412
 sysconfig/product/permissions/android.hardware.telephony.euicc.xml: 211bb53d65e73aedfb0a9afb4d65e5891417811ae28d2438324d6b3f3b5bde0d
-sysconfig/product/permissions/android.hardware.telephony.satellite.xml: e18ea780088a89016a5115e7624da6cb21ec2747a3033b1dd0ca7c66fc4002c5
 sysconfig/product/permissions/androidx.camera.extensions.impl.xml: 2f608136ec90b7331625c1cd63965fe4d2227affe2db331f00e3200aa1d81a98
 sysconfig/product/permissions/com.google.android.dialer.support.xml: 42c0ad27676d0b7d21150d6586672b2567ac272f5f24657110914b090631bdb7
 sysconfig/product/permissions/com.google.pixel.camera.connectivity.impl.xml: 2e4338cd3a461a36a6a72ac8fbafa76ea8f158b160766b4d3bd2d6e982eb6e96


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7747

Integrating PixelSatelliteService (config_satellite_service_package), VendorSatelliteService, and SatelliteGatewayPrebuilt (Stargate; config_satellite_gateway_service_package) would be its own undertaking. Including this feature without the satellite packages can cause apps that use satellite state callbacks to hang if they rely on the callback to fire to continue on in their code. Android Auto 16.6.661444 is one such example for its cellular signal icon in the headunit.

The Pixel satellite gateway service package, Stargate, has reliance on Play services and has authentication code, etc. While we could try to include PixelSatelliteService and VendorSatelliteService, there probably would be not much of a point without the gateway service package, since it doesn't seem like user-facing features would be available without Stargate. For example, satellite/SOS messages in Google Messages uses gRPC with the Stargate package. It's not even implied to be a completely free service; on stock OS, the Pixel Satellite SOS footer says, "Satellite SOS is included at no charge for 2 years."

Remove the feature for now so that apps stop using satellite state callbacks.

Test: Android Auto 16.6.661444 cellular signal icon is showing again on a Pixel that has satellite support in hardware (caiman)