### PR TITLE
stallion: add missing selinux file context for edgetpu_app_service

### DIFF
--- a/config/mk/google_devices/device/stallion/BoardConfig-base.mk
+++ b/config/mk/google_devices/device/stallion/BoardConfig-base.mk
@@ -1,1 +1,3 @@
 include vendor/adevtool/config/mk/google_devices/platform/zumapro/BoardConfig-common.mk
+
+BOARD_VENDOR_SEPOLICY_DIRS += vendor/adevtool/config/mk/google_devices/device/stallion/sepolicy/vendor

--- a/config/mk/google_devices/device/stallion/sepolicy/vendor/file_contexts
+++ b/config/mk/google_devices/device/stallion/sepolicy/vendor/file_contexts
@@ -1,0 +1,1 @@
+/vendor/lib64/com\.google\.edgetpu_app_service-V6-ndk\.so    u:object_r:same_process_hal_file:s0


### PR DESCRIPTION
resolves https://github.com/GrapheneOS/os-issue-tracker/issues/7679