### PR TITLE
gos-dhdutil: fix compilation for Android 17

### DIFF
--- a/config/mk/google_devices/common/gos-dhdutil/src/main.rs
+++ b/config/mk/google_devices/common/gos-dhdutil/src/main.rs
@@ -1,4 +1,4 @@
-use rustutils::system_properties;
+use rustutils::android::system_properties;
 use std::io;
 use std::mem;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};


### PR DESCRIPTION
Due to https://android.googlesource.com/platform/system/librustutils/+/a194b9ba3ef67cad27611ddded046448a86d092c