### PR TITLE
Fix tsc errors

### DIFF
--- a/src/blobs/carrier.ts
+++ b/src/blobs/carrier.ts
@@ -60,7 +60,7 @@ export async function fetchUpdateConfig(
     log(`requestData: ${outFile}`)
     await fs.writeFile(outFile, JSON.stringify(Request.toJSON(requestData), null, 4))
   }
-  const encodedRequest = Request.encode(requestData).finish()
+  const encodedRequest = Buffer.from(Request.encode(requestData).finish())
   if (debug) {
     const reqFile = path.join(tmpDir, 'encodedRequestData')
     await fs.writeFile(reqFile, encodedRequest)

--- a/src/commands/collect-state.ts
+++ b/src/commands/collect-state.ts
@@ -320,7 +320,7 @@ async function runStateCollectionBuild(
       break
     } catch (e) {
       logElapsedTime(buildStart, `${device} phase ${phase} state collection build failed in`)
-      let stderr = e.message as string
+      let stderr = (e as Error).message as string
       if (stderr !== undefined) {
         log(`\n${statusPrefix}stderr:\n` + stderr)
       }

--- a/src/commands/fetch-build-index.ts
+++ b/src/commands/fetch-build-index.ts
@@ -1,5 +1,5 @@
 import { Command, Flags } from '@oclif/core'
-import { YAMLMap } from 'yaml/types'
+import { YAMLMap } from 'yaml'
 
 import assert from 'assert'
 import YAML, { Document } from 'yaml'

--- a/src/commands/update-carrier-settings.ts
+++ b/src/commands/update-carrier-settings.ts
@@ -1,4 +1,5 @@
 import { Command, Flags } from '@oclif/core'
+import util from 'util'
 
 import { downloadAllConfigs, fetchUpdateConfig, getCarrierSettingsUpdatesDir } from '../blobs/carrier'
 import { BUILD_VERSION_SDK_PROP, loadPartitionProps } from '../blobs/props'
@@ -46,7 +47,7 @@ export default class UpdateCarrierSettings extends Command {
           )
           let sdkVersion = mapGet(mapGet(stockProps, Partition.System), BUILD_VERSION_SDK_PROP)
           const updateConfig = await fetchUpdateConfig(config.device.name, buildId, sdkVersion, flags.debug)
-          if (flags.debug) log(updateConfig)
+          if (flags.debug) log(util.inspect(updateConfig, false, Infinity))
           await downloadAllConfigs(updateConfig, outDir, flags.debug)
         } else {
           this.log(`${config.device.name} is not supported due to lack of cellular connectivity`)

--- a/src/frontend/source.ts
+++ b/src/frontend/source.ts
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import { createReadStream, promises as fs } from 'fs'
+import { createReadStream, promises as fs, ReadOptionsWithBuffer } from 'fs'
 import { FileHandle, FileReadOptions } from 'fs/promises'
 import hasha from 'hasha'
 import path from 'path'
@@ -584,11 +584,12 @@ class FdReader extends yauzl.Reader {
     // do not initialize buffer contents, assert below ensures that it's fully written out
     let buffer = Buffer.allocUnsafe(length)
 
-    let opts = {
-      buffer,
-      length,
+    let opts: ReadOptionsWithBuffer<any> = {
+      buffer: buffer,
+      length: length,
+      offset: 0,
       position: this.off + start,
-    } as FileReadOptions
+    }
 
     assert((await this.fd.read(opts)).bytesRead === length)
     return buffer

--- a/src/images/build-index.ts
+++ b/src/images/build-index.ts
@@ -2,7 +2,7 @@ import assert from 'assert'
 import { JSDOM } from 'jsdom'
 import fetch from 'node-fetch'
 import path from 'path'
-import { Document, YAMLMap } from 'yaml'
+import { Document as YAMLDocument, YAMLMap } from 'yaml'
 
 import { loadAndMergeConfig } from '../config/config-loader'
 import { DeviceBuildId, DeviceConfig, makeDeviceBuildId } from '../config/device'
@@ -108,7 +108,7 @@ async function fetchBuildIndexInner(
     }
   }
 
-  return new Document().createNode(buildIndex) as YAMLMap
+  return new YAMLDocument().createNode(buildIndex) as YAMLMap
 }
 
 function parseFactoryOrOtaPage(buildIndex: BuildIndex, pageType: string, dom: JSDOM, devices: Set<string>) {

--- a/src/images/download.ts
+++ b/src/images/download.ts
@@ -84,6 +84,10 @@ async function downloadImageInner(
   if (!resp.ok) {
     throw new Error(`${resp.status}: ${resp.statusText}; ${image.toString()} `)
   }
+  if (resp.body === null) {
+    throw new Error(`missing response body for ${image.toString()}`)
+  }
+
 
   let downloaded = 0
   let totalSizeStr: string | null

--- a/src/util/exact-filter.ts
+++ b/src/util/exact-filter.ts
@@ -81,7 +81,7 @@ interface FilterEntries2Result<T> {
   hasTransforms: boolean
 }
 
-export function filterEntries2<T>(cmd: EntryFilter2Cmd<T>) {
+export function filterEntries2<T extends Record<string, unknown>>(cmd: EntryFilter2Cmd<T>) {
   let unknownEntries: string[] = []
   let filtered: [string, T][] = []
   let hasTransforms = false

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -69,7 +69,7 @@ function updateStatusLines() {
   }
 }
 
-let pendingWrites: unknown[] = []
+let pendingWrites: (string | Buffer | Uint8Array)[] = []
 let currentStatus: string | null = null
 
 let isClearPending = false

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -149,7 +149,7 @@ function write(str: string | Buffer | Uint8Array, callback?: () => void) {
   }
 }
 
-export function log(str: string | Buffer | DataView) {
+export function log(str: string | Buffer | Uint8Array) {
   if (currentStatus !== null) {
     clearStatusLines()
     write(str)


### PR DESCRIPTION
This PR tries to fix some of the tsc errors.
Before this patch:
```
src/blobs/carrier.ts:78:5 - error TS2345: Argument of type '{ method: string; headers: { 'Content-Type': string; }; body: Uint8Array<ArrayBuffer>; }' is not assignable to parameter of type 'RequestInit'.
  Types of property 'body' are incompatible.
    Type 'Uint8Array<ArrayBuffer>' is not assignable to type 'BodyInit | null | undefined'.
      Type 'Uint8Array<ArrayBuffer>' is missing the following properties from type 'Buffer<ArrayBufferLike>': write, toJSON, equals, compare, and 66 more.

78     options,
       ~~~~~~~

src/commands/apply-bulletin-patches.ts:356:78 - error TS2552: Cannot find name 'baseRevision'. Did you mean 'revision'?

356         if (spawnSync('git', ['-C', repoPath, 'diff', '--exit-code', 'HEAD', baseRevision]).status !== 0) {
                                                                                 ~~~~~~~~~~~~

  src/commands/apply-bulletin-patches.ts:204:9
    204     let revision = manifestConfig.revision
                ~~~~~~~~
    'revision' is declared here.

src/commands/apply-bulletin-patches.ts:357:47 - error TS2552: Cannot find name 'baseRevision'. Did you mean 'revision'?

357           patchedRepos.push({ path: repoPath, baseRevision })
                                                  ~~~~~~~~~~~~

  src/commands/apply-bulletin-patches.ts:204:9
    204     let revision = manifestConfig.revision
                ~~~~~~~~
    'revision' is declared here.

src/commands/apply-bulletin-patches.ts:359:39 - error TS2552: Cannot find name 'baseRevision'. Did you mean 'revision'?

359           console.log(`${repoPath}: ${baseRevision} is same as HEAD`)
                                          ~~~~~~~~~~~~

  src/commands/apply-bulletin-patches.ts:204:9
    204     let revision = manifestConfig.revision
                ~~~~~~~~
    'revision' is declared here.

src/commands/collect-state.ts:323:20 - error TS18046: 'e' is of type 'unknown'.

323       let stderr = e.message as string
                       ~

src/commands/fetch-build-index.ts:2:25 - error TS2307: Cannot find module 'yaml/types' or its corresponding type declarations.

2 import { YAMLMap } from 'yaml/types'
                          ~~~~~~~~~~~~

src/commands/update-carrier-settings.ts:49:32 - error TS2345: Argument of type 'Map<string, string>' is not assignable to parameter of type 'string | Buffer<ArrayBufferLike> | DataView<ArrayBufferLike>'.
  Type 'Map<string, string>' is missing the following properties from type 'DataView<ArrayBufferLike>': buffer, byteLength, byteOffset, getFloat32, and 21 more.

49           if (flags.debug) log(updateConfig)
                                  ~~~~~~~~~~~~

src/frontend/source.ts:593:32 - error TS2769: No overload matches this call.
  Overload 1 of 3, '(buffer: ArrayBufferView<ArrayBufferLike>, offset?: number | null | undefined, length?: number | null | undefined, position?: ReadPosition | null | undefined): Promise<...>', gave the following error.
    Argument of type 'FileReadOptions<Buffer<ArrayBufferLike>>' is not assignable to parameter of type 'ArrayBufferView<ArrayBufferLike>'.
      Type 'FileReadOptions<Buffer<ArrayBufferLike>>' is missing the following properties from type 'Float64Array<ArrayBufferLike>': BYTES_PER_ELEMENT, byteLength, byteOffset, copyWithin, and 30 more.
  Overload 2 of 3, '(buffer: ArrayBufferView<ArrayBufferLike>, options?: ReadOptions | undefined): Promise<FileReadResult<ArrayBufferView<ArrayBufferLike>>>', gave the following error.
    Argument of type 'FileReadOptions<Buffer<ArrayBufferLike>>' is not assignable to parameter of type 'ArrayBufferView<ArrayBufferLike>'.
      Type 'FileReadOptions<Buffer<ArrayBufferLike>>' is missing the following properties from type 'Float64Array<ArrayBufferLike>': BYTES_PER_ELEMENT, byteLength, byteOffset, copyWithin, and 30 more.
  Overload 3 of 3, '(options?: ReadOptionsWithBuffer<Buffer<ArrayBufferLike>> | undefined): Promise<FileReadResult<Buffer<ArrayBufferLike>>>', gave the following error.
    Argument of type 'FileReadOptions<Buffer<ArrayBufferLike>>' is not assignable to parameter of type 'ReadOptionsWithBuffer<Buffer<ArrayBufferLike>>'.
      Types of property 'offset' are incompatible.
        Type 'number | null | undefined' is not assignable to type 'number | undefined'.
          Type 'null' is not assignable to type 'number | undefined'.

593     assert((await this.fd.read(opts)).bytesRead === length)
                                   ~~~~


src/images/build-index.ts:166:7 - error TS2740: Type 'Document' is missing the following properties from type 'Document<Node, true>': commentBefore, comment, contents, directives, and 22 more.

166   let doc: Document = dom.window.document
          ~~~

src/images/build-index.ts:167:19 - error TS2339: Property 'querySelector' does not exist on type 'Document<Node, true>'.

167   let table = doc.querySelector('#images > tbody') as HTMLTableElement
                      ~~~~~~~~~~~~~

src/images/build-index.ts:199:24 - error TS2339: Property 'getElementById' does not exist on type 'Document<Node, true>'.

199     let dlButton = doc.getElementById(`agree-button__${device}_${pageType}_zip`) as HTMLAnchorElement
                           ~~~~~~~~~~~~~~

src/images/download.ts:106:3 - error TS18047: 'resp.body' is possibly 'null'.

106   resp.body.on('data', chunk => {
      ~~~~~~~~~

src/images/download.ts:122:18 - error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type 'ReadableStream | null' is not assignable to parameter of type 'PipelineSource<any>'.
      Type 'null' is not assignable to type 'PipelineSource<any>'.

122   await pipeline(resp.body, createWriteStream(tmpOutFile, { flags: 'a' /* append */ }))
                     ~~~~~~~~~

  node_modules/@types/node/stream/promises.d.ts:200:14
    200     function pipeline(
                     ~~~~~~~~
    The last overload is declared here.

src/util/exact-filter.ts:90:9 - error TS7053: Element implicitly has an 'any' type because expression of type '"#text"' can't be used to index type 'unknown'.
  Property '#text' does not exist on type 'unknown'.

90     if (pair[1]['#text'] === '.' && Object.keys(pair[1]).length === 1) {
           ~~~~~~~~~~~~~~~~

src/util/exact-filter.ts:90:49 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(o: {}): string[]', gave the following error.
    Argument of type 'T' is not assignable to parameter of type '{}'.
  Overload 2 of 2, '(o: object): string[]', gave the following error.
    Argument of type 'T' is not assignable to parameter of type 'object'.

90     if (pair[1]['#text'] === '.' && Object.keys(pair[1]).length === 1) {
                                                   ~~~~~~~

  src/util/exact-filter.ts:84:32
    84 export function filterEntries2<T>(cmd: EntryFilter2Cmd<T>) {
                                      ~
    This type parameter might need an `extends {}` constraint.
  src/util/exact-filter.ts:84:32
    84 export function filterEntries2<T>(cmd: EntryFilter2Cmd<T>) {
                                      ~
    This type parameter might need an `extends object` constraint.

src/util/log.ts:91:17 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string | Buffer<ArrayBufferLike> | Uint8Array<ArrayBufferLike>'.

91           write(w)
                   ~

src/util/log.ts:133:1 - error TS2322: Type '(chunk: string | Uint8Array<ArrayBufferLike>, encoding: BufferEncoding | undefined, callback: ((err?: Error | null | undefined) => void) | undefined) => void' is not assignable to type '{ (buffer: string | Uint8Array<ArrayBufferLike>, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string | Uint8Array<ArrayBufferLike>, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | ... 1 more ... | undefined) => void) | undefined): boolean; }'.
  Target signature provides too few arguments. Expected 3 or more, but got 2.

133 process.stdout.write = (chunk, encoding, callback) => {
    ~~~~~~~~~~~~~~~~~~~~

src/util/log.ts:155:11 - error TS2345: Argument of type 'string | Buffer<ArrayBufferLike> | DataView<ArrayBufferLike>' is not assignable to parameter of type 'string | Buffer<ArrayBufferLike> | Uint8Array<ArrayBufferLike>'.
  Type 'DataView<ArrayBufferLike>' is not assignable to type 'string | Buffer<ArrayBufferLike> | Uint8Array<ArrayBufferLike>'.
    Type 'DataView<ArrayBufferLike>' is missing the following properties from type 'Uint8Array<ArrayBufferLike>': BYTES_PER_ELEMENT, copyWithin, every, fill, and 28 more.

155     write(str)
              ~~~

src/util/log.ts:157:11 - error TS2345: Argument of type 'string | Buffer<ArrayBufferLike> | DataView<ArrayBufferLike>' is not assignable to parameter of type 'string | Buffer<ArrayBufferLike> | Uint8Array<ArrayBufferLike>'.
  Type 'DataView<ArrayBufferLike>' is not assignable to type 'string | Buffer<ArrayBufferLike> | Uint8Array<ArrayBufferLike>'.
    Type 'DataView<ArrayBufferLike>' is missing the following properties from type 'Uint8Array<ArrayBufferLike>': BYTES_PER_ELEMENT, copyWithin, every, fill, and 28 more.

157     write(str)
              ~~~

src/util/process.ts:60:5 - error TS2542: Index signature in type 'StdioOptions' only permits reading.

60     stdio[1] = fh.fd
       ~~~~~~~~


Found 20 errors.
```
After this patch:
```
src/commands/apply-bulletin-patches.ts:356:78 - error TS2552: Cannot find name 'baseRevision'. Did you mean 'revision'?

356         if (spawnSync('git', ['-C', repoPath, 'diff', '--exit-code', 'HEAD', baseRevision]).status !== 0) {
                                                                                 ~~~~~~~~~~~~

  src/commands/apply-bulletin-patches.ts:204:9
    204     let revision = manifestConfig.revision
                ~~~~~~~~
    'revision' is declared here.

src/commands/apply-bulletin-patches.ts:357:47 - error TS2552: Cannot find name 'baseRevision'. Did you mean 'revision'?

357           patchedRepos.push({ path: repoPath, baseRevision })
                                                  ~~~~~~~~~~~~

  src/commands/apply-bulletin-patches.ts:204:9
    204     let revision = manifestConfig.revision
                ~~~~~~~~
    'revision' is declared here.

src/commands/apply-bulletin-patches.ts:359:39 - error TS2552: Cannot find name 'baseRevision'. Did you mean 'revision'?

359           console.log(`${repoPath}: ${baseRevision} is same as HEAD`)
                                          ~~~~~~~~~~~~

  src/commands/apply-bulletin-patches.ts:204:9
    204     let revision = manifestConfig.revision
                ~~~~~~~~
    'revision' is declared here.

src/util/log.ts:133:1 - error TS2322: Type '(chunk: string | Uint8Array<ArrayBufferLike>, encoding: BufferEncoding | undefined, callback: ((err?: Error | null | undefined) => void) | undefined) => void' is not assignable to type '{ (buffer: string | Uint8Array<ArrayBufferLike>, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string | Uint8Array<ArrayBufferLike>, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | ... 1 more ... | undefined) => void) | undefined): boolean; }'.
  Target signature provides too few arguments. Expected 3 or more, but got 2.

133 process.stdout.write = (chunk, encoding, callback) => {
    ~~~~~~~~~~~~~~~~~~~~

src/util/process.ts:60:5 - error TS2542: Index signature in type 'StdioOptions' only permits reading.

60     stdio[1] = fh.fd
       ~~~~~~~~


Found 5 errors.
```