### PR TITLE
set 10 GiB super partition size for 11th gen Pixels

### DIFF
--- a/config/mk/google_devices/platform/malibu/BoardConfig-common.mk
+++ b/config/mk/google_devices/platform/malibu/BoardConfig-common.mk
@@ -5,6 +5,12 @@ include vendor/adevtool/config/mk/google_devices/common/BoardConfig-armv9.mk
 
 include vendor/adevtool/config/mk/google_devices/common/BoardConfig-common-gs201-plus.mk
 
+BOARD_SUPER_PARTITION_SIZE := 10737418240
+# Set size to BOARD_SUPER_PARTITION_SIZE - overhead (4MiB) (b/182237294)
+BOARD_GOOGLE_DYNAMIC_PARTITIONS_SIZE := 10733223936
+# Set error limit to BOARD_SUPER_PARTITION_SIZE - 500MB
+BOARD_SUPER_PARTITION_ERROR_LIMIT := 10213130240
+
 BOARD_PRODUCTIMAGE_FILE_SYSTEM_TYPE := erofs
 BOARD_SYSTEM_DLKMIMAGE_FILE_SYSTEM_TYPE := erofs
 BOARD_SYSTEM_EXTIMAGE_FILE_SYSTEM_TYPE := erofs


### PR DESCRIPTION
11th gen Pixels use a 10 GiB physical super partition. Without this override they inherit the 8531214336-byte value from config/mk/google_devices/common/BoardConfig-common.mk. The stale value permits building, factory flashing and booting, but records the wrong block device size in LP metadata.

update_engine rejects OTAs using the corrected dynamic partition group because it derives allocatable space from the installed source metadata. Devices installed from builds prior to this change must be reflashed with a corrected installation package using the normal flash-all.sh wipe flow before OTA testing.

Verify on a running device from a root shell:

    blockdev --getsize64 /dev/block/by-name/super

Verify with an unpacked factory image by running:

    lpdump -j <unpacked-factory-image>/super_empty.img

kodiak and yogi report a 10737418240-byte super device and 10733223936-byte dynamic partition groups.