### PR TITLE
GosOverlay: remove config_availableColorModes to remove Saturated mode in Settings

### DIFF
--- a/config/mk/google_devices/platform/gs101/gos-overlays/GosOverlay/res/values/values.xml
+++ b/config/mk/google_devices/platform/gs101/gos-overlays/GosOverlay/res/values/values.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <integer-array name="config_availableColorModes">
-        <item>0</item> <!-- COLOR_MODE_NATURAL -->
-        <item>256</item> <!-- vendor color mode boosted -->
-        <item>2</item> <!-- COLOR_MODE_SATURATED -->
-        <item>3</item> <!-- COLOR_MODE_AUTOMATIC -->
-    </integer-array>
-
     <!-- Exempt ImsService from privacy (location) indicators -->
     <string name="config_systemTelephonyPackage" translatable="false">com.shannon.imsservice</string>
 

--- a/config/mk/google_devices/platform/gs101/overlay-excluded-from-enforce-rro-targets/packages/apps/Settings/res/values/config.xml
+++ b/config/mk/google_devices/platform/gs101/overlay-excluded-from-enforce-rro-targets/packages/apps/Settings/res/values/config.xml
@@ -7,7 +7,6 @@
         <item>@string/color_mode_option_natural</item>
         <item>@string/color_mode_option_boosted</item>
         <item>@string/color_mode_option_boosted</item>
-        <item>@string/color_mode_option_saturated</item>
         <item>@string/color_mode_option_automatic</item>
     </string-array>
     <!-- Display settings screen, Color mode options. Must be the same length and order as
@@ -22,8 +21,6 @@
         <item>1</item>
         <!-- gs101-specific boosted color mode-->
         <item>256</item>
-        <!-- COLOR_MODE_SATURATED-->
-        <item>2</item>
         <!-- COLOR_MODE_AUTOMATIC-->
         <item>3</item>
     </integer-array>

--- a/config/mk/google_devices/platform/gs201/gos-overlays/GosOverlay/res/values/values.xml
+++ b/config/mk/google_devices/platform/gs201/gos-overlays/GosOverlay/res/values/values.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <integer-array name="config_availableColorModes">
-        <item>0</item> <!-- COLOR_MODE_NATURAL -->
-        <item>2</item> <!-- COLOR_MODE_SATURATED -->
-        <item>3</item> <!-- COLOR_MODE_AUTOMATIC -->
-    </integer-array>
-
     <!-- Exempt ImsService from privacy (location) indicators -->
     <string name="config_systemTelephonyPackage" translatable="false">com.shannon.imsservice</string>
 

--- a/config/mk/google_devices/platform/laguna/gos-overlays/GosOverlay/res/values/values.xml
+++ b/config/mk/google_devices/platform/laguna/gos-overlays/GosOverlay/res/values/values.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <integer-array name="config_availableColorModes">
-        <item>0</item> <!-- COLOR_MODE_NATURAL -->
-        <item>2</item> <!-- COLOR_MODE_SATURATED -->
-        <item>3</item> <!-- COLOR_MODE_AUTOMATIC -->
-    </integer-array>
-
-
     <!-- Exempt ImsService from privacy (location) indicators -->
     <string name="config_systemTelephonyPackage" translatable="false">com.shannon.imsservice</string>
 

--- a/config/mk/google_devices/platform/malibu/gos-overlays/GosOverlay/res/values/values.xml
+++ b/config/mk/google_devices/platform/malibu/gos-overlays/GosOverlay/res/values/values.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <integer-array name="config_availableColorModes">
-        <item>0</item> <!-- COLOR_MODE_NATURAL -->
-        <item>2</item> <!-- COLOR_MODE_SATURATED -->
-        <item>3</item> <!-- COLOR_MODE_AUTOMATIC -->
-    </integer-array>
-
     <bool name="config_Google_apps_can_have_special_access_to_accelerators">true</bool>
 
     <bool name="config_GoogleCamera_needs_seinfo_for_access_to_accelerators">true</bool>

--- a/config/mk/google_devices/platform/zuma/gos-overlays/GosOverlay/res/values/values.xml
+++ b/config/mk/google_devices/platform/zuma/gos-overlays/GosOverlay/res/values/values.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <integer-array name="config_availableColorModes">
-        <item>0</item> <!-- COLOR_MODE_NATURAL -->
-        <item>2</item> <!-- COLOR_MODE_SATURATED -->
-        <item>3</item> <!-- COLOR_MODE_AUTOMATIC -->
-    </integer-array>
-
     <!-- Exempt ImsService from privacy (location) indicators -->
     <string name="config_systemTelephonyPackage" translatable="false">com.shannon.imsservice</string>
 

--- a/config/mk/google_devices/platform/zumapro/gos-overlays/GosOverlay/res/values/values.xml
+++ b/config/mk/google_devices/platform/zumapro/gos-overlays/GosOverlay/res/values/values.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <integer-array name="config_availableColorModes">
-        <item>0</item> <!-- COLOR_MODE_NATURAL -->
-        <item>2</item> <!-- COLOR_MODE_SATURATED -->
-        <item>3</item> <!-- COLOR_MODE_AUTOMATIC -->
-    </integer-array>
-
     <!-- Exempt ImsService from privacy (location) indicators -->
     <string name="config_systemTelephonyPackage" translatable="false">com.shannon.imsservice</string>
 


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/8336

Stock Pixel overlays do not list Saturated in `config_availableColorModes`, so it is not supported by the stock Pixel configuration. For example, the extracted Pixel 8 framework overlay is at:

https://github.com/GrapheneOS/adevtool/blob/2026081300/vendor-skels/google_devices/shiba/overlays/framework-res__shiba__auto_generated_rro_vendor/res/values/values.xml#L148-L151

Overriding this resource to expose color modes not exposed upstream can lead to upstream bugs. e.g. allowing the user to select Saturated color mode can lead to an upstream bug that prevents Pixel HWC implementations using libexynosdisplay.so from clearing an accessibility color transform. Since stock Pixels don't have Saturated mode, it's unlikely that this will get fixed upstream. (This bug doesn't affect non-libexynosdisplay.so Pixels like 10th-gen Pixels other than 10a.)

Use the stock vendor overlay definitions instead which don't include Saturated. Existing Saturated settings are handled by `config_mappedColorModes` in stock vendor overlay.