### PR TITLE
set default display color mode to Natural

### DIFF
--- a/config/mk/google_devices/common/device-common.mk
+++ b/config/mk/google_devices/common/device-common.mk
@@ -35,10 +35,6 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/emulated_storage.mk)
 # Enforce generic ramdisk allow list
 $(call inherit-product, $(SRC_TARGET_DIR)/product/generic_ramdisk.mk)
 
-# use the Natural display color mode by default
-PRODUCT_PROPERTY_OVERRIDES += \
-	persist.sys.sf.color_saturation=1.0
-
 PRODUCT_CHARACTERISTICS := nosdcard
 
 WIFI_PRIV_CMD_UPDATE_MBO_CELL_STATUS := enabled

--- a/config/mk/google_devices/platform/gs101/gos-overlays/GosOverlay/res/values/values.xml
+++ b/config/mk/google_devices/platform/gs101/gos-overlays/GosOverlay/res/values/values.xml
@@ -5,6 +5,8 @@
 
     <bool name="config_Google_apps_can_have_special_access_to_accelerators">true</bool>
 
+    <integer name="setting_default_display_color_mode">0</integer> <!-- COLOR_MODE_NATURAL -->
+
     <string name="config_gnssPsdsType">broadcom</string>
 
     <bool name="config_usbPortSecuritySupported">true</bool>

--- a/config/mk/google_devices/platform/gs201/gos-overlays/GosOverlay/res/values/values.xml
+++ b/config/mk/google_devices/platform/gs201/gos-overlays/GosOverlay/res/values/values.xml
@@ -7,6 +7,8 @@
 
     <bool name="config_GoogleCamera_needs_seinfo_for_access_to_accelerators">true</bool>
 
+    <integer name="setting_default_display_color_mode">0</integer> <!-- COLOR_MODE_NATURAL -->
+
     <string name="config_gnssPsdsType">broadcom</string>
 
     <bool name="config_usbPortSecuritySupported">true</bool>

--- a/config/mk/google_devices/platform/laguna/gos-overlays/GosOverlay/res/values/values.xml
+++ b/config/mk/google_devices/platform/laguna/gos-overlays/GosOverlay/res/values/values.xml
@@ -7,6 +7,8 @@
 
     <bool name="config_GoogleCamera_needs_seinfo_for_access_to_accelerators">true</bool>
 
+    <integer name="setting_default_display_color_mode">0</integer> <!-- COLOR_MODE_NATURAL -->
+
     <string name="config_gnssPsdsType">samsung</string>
 
     <bool name="config_usbPortSecuritySupported">true</bool>

--- a/config/mk/google_devices/platform/malibu/gos-overlays/GosOverlay/res/values/values.xml
+++ b/config/mk/google_devices/platform/malibu/gos-overlays/GosOverlay/res/values/values.xml
@@ -4,6 +4,8 @@
 
     <bool name="config_GoogleCamera_needs_seinfo_for_access_to_accelerators">true</bool>
 
+    <integer name="setting_default_display_color_mode">0</integer> <!-- COLOR_MODE_NATURAL -->
+
     <string name="config_gnssPsdsType">mediatek</string>
 
     <bool name="config_usbPortSecuritySupported">true</bool>

--- a/config/mk/google_devices/platform/zuma/gos-overlays/GosOverlay/res/values/values.xml
+++ b/config/mk/google_devices/platform/zuma/gos-overlays/GosOverlay/res/values/values.xml
@@ -7,6 +7,8 @@
 
     <bool name="config_GoogleCamera_needs_seinfo_for_access_to_accelerators">true</bool>
 
+    <integer name="setting_default_display_color_mode">0</integer> <!-- COLOR_MODE_NATURAL -->
+
     <string name="config_gnssPsdsType">broadcom</string>
 
     <bool name="config_usbPortSecuritySupported">true</bool>

--- a/config/mk/google_devices/platform/zumapro/gos-overlays/GosOverlay/res/values/values.xml
+++ b/config/mk/google_devices/platform/zumapro/gos-overlays/GosOverlay/res/values/values.xml
@@ -7,6 +7,8 @@
 
     <bool name="config_GoogleCamera_needs_seinfo_for_access_to_accelerators">true</bool>
 
+    <integer name="setting_default_display_color_mode">0</integer> <!-- COLOR_MODE_NATURAL -->
+
     <string name="config_gnssPsdsType">samsung</string>
 
     <bool name="config_usbPortSecuritySupported">true</bool>


### PR DESCRIPTION
Requires https://github.com/GrapheneOS/platform_frameworks_base/pull/439

Test: after `fastboot flashall -w`, `persist.sys.sf.color_saturation` is still set in SF defaults:
```
shiba:/ $ settings get system display_color_mode
0
shiba:/ $ getprop persist.sys.sf.native_mode
0
shiba:/ $ getprop persist.sys.sf.color_saturation
1.0
```

Natural remains selected after toggling color inversion in accessibility settings